### PR TITLE
fix: Azure API throttling error & incorrect page size request for workflows

### DIFF
--- a/cmd/list-storage-containers.go
+++ b/cmd/list-storage-containers.go
@@ -68,7 +68,12 @@ func listStorageContainers(ctx context.Context, client client.AzureClient, stora
 	var (
 		out     = make(chan interface{})
 		ids     = make(chan interface{})
-		streams = pipeline.Demux(ctx.Done(), ids, 25)
+		// The original size of the demuxxer cascaded into error messages for a lot of collection steps.
+		// Decreasing the demuxxer size only here is sufficient to prevent the cascade
+		// The error message with higher values for size is
+		// "The request was throttled."
+		// See issue #7: https://github.com/BloodHoundAD/AzureHound/issues/7
+		streams = pipeline.Demux(ctx.Done(), ids, 2)
 		wg      sync.WaitGroup
 	)
 

--- a/cmd/list-workflows.go
+++ b/cmd/list-workflows.go
@@ -20,7 +20,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"math"
 	"os"
 	"os/signal"
 	"sync"
@@ -90,7 +89,12 @@ func listWorkflows(ctx context.Context, client client.AzureClient, subscriptions
 			defer wg.Done()
 			for id := range stream {
 				count := 0
-				for item := range client.ListAzureWorkflows(ctx, id, "", math.MaxInt32) {
+				// Azure only allows requesting 100 workflows at a time. The previous
+				// value of math.MaxInt32 was causing issues and not collecting
+				// workflows at all. This is not a great fix, since it requires proper
+				// pagination in case there are more than 100 workflows, but it's better
+				// as an interim solution than it was before.
+				for item := range client.ListAzureWorkflows(ctx, id, "", 100) {
 					if item.Error != nil {
 						log.Error(item.Error, "unable to continue processing workflows for this subscription", "subscriptionId", id)
 					} else {


### PR DESCRIPTION
This PR fixes two issues which only seem to occur in (very) large environments.

1. The current AzureHound version results in a lot of "The request was throttled." error messages from the Azure API. The root cause seems to be the collection command "list-storage-containers" which then cascades into the same throttling for other collection methods.  See also here: https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#storage-resource-provider-limits. By tuning down the concurrency of this storage command, all other throttling issues seem to disappear. This issue is also reported already as issue #7 . 
2. The following error occurs when collecting workbooks: 
```Error: map[error:map[code:InvalidTopInQueryString message:The value '2147483647' was provided for top; a value less than or equal to '1000' must be provided.]]```
So changed the value to 1000, got a similar error. Changed to 999 to compensate for an off-by-one on Azure's side, but still got the same error
``` Error: map[error:map[code:PageSizeLimitExceeded message:The requested page size of '999' exceeds the allowed limit of '100'.]] ```
Setting the value to 100 fixes the issue. This is not a permanent fix, as obviously there could be more than 100 workbooks in that subscription. However, at least it collects some data for now, until there is a more permanent fix. 

Results for comparison: the rolling version without this patch collects an output file of 4.2GB after this patch  the output is 31GB. 