### PR TITLE
feat: implement the retry guidance from microsoft

### DIFF
--- a/client/rest/client.go
+++ b/client/rest/client.go
@@ -25,6 +25,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -33,11 +34,6 @@ import (
 
 	"github.com/bloodhoundad/azurehound/client/config"
 	"github.com/bloodhoundad/azurehound/constants"
-)
-
-const (
-	initBackoff time.Duration = 5 * time.Second
-	maxRetries  int           = 3
 )
 
 type RestClient interface {
@@ -144,7 +140,7 @@ func (s *restClient) Authenticate() error {
 
 	if req, err := NewRequest(context.Background(), "POST", endpoint, body, nil, nil); err != nil {
 		return err
-	} else if res, err := s.send(req, 0, initBackoff); err != nil {
+	} else if res, err := s.send(req); err != nil {
 		return err
 	} else {
 		defer res.Body.Close()
@@ -219,7 +215,7 @@ func (s *restClient) Send(req *http.Request) (*http.Response, error) {
 		}
 		req.Header.Set("Authorization", s.token.String())
 	}
-	return s.send(req, 0, initBackoff)
+	return s.send(req)
 }
 
 func copyBody(req *http.Request) ([]byte, error) {
@@ -229,57 +225,67 @@ func copyBody(req *http.Request) ([]byte, error) {
 	)
 	if req.Body != nil {
 		body, err = io.ReadAll(req.Body)
-		setBody(req, body)
+		if body != nil {
+			req.Body = io.NopCloser(bytes.NewBuffer(body))
+		}
 	}
 	return body, err
 }
 
-func setBody(req *http.Request, body []byte) {
-	if body != nil {
-		req.Body = io.NopCloser(bytes.NewBuffer(body))
-	}
-}
-
-func (s *restClient) send(req *http.Request, attempt int, backoff time.Duration) (*http.Response, error) {
+func (s *restClient) send(req *http.Request) (*http.Response, error) {
 	// copy the bytes in case we need to retry the request
-	body, err := copyBody(req)
-	if err != nil {
+	if body, err := copyBody(req); err != nil {
 		return nil, err
-	}
+	} else {
+		var (
+			res        *http.Response
+			err        error
+			maxRetries = 3
+		)
+		// Try the request up to a set number of times
+		for retry := 0; retry < maxRetries; retry++ {
 
-	res, err := s.http.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusBadRequest {
-		// See official Retry guidance (https://learn.microsoft.com/en-us/azure/architecture/best-practices/retry-service-specific#retry-usage-guidance)
-		if res.StatusCode == http.StatusTooManyRequests {
-			retryAfter := res.Header.Get("Retry-After")
-			if sleep, err := strconv.ParseInt(retryAfter, 10, 64); err != nil {
-				return nil, fmt.Errorf("unable to parse retry-after header: %w", err)
-			} else {
-				time.Sleep(time.Second * time.Duration(sleep))
-				// Need to rewind the request body back to its original state
-				setBody(req, body)
-				attempt++
-				return s.send(req, attempt, backoff)
+			// Reusing http.Request requires rewinding the request body
+			// back to a working state
+			if body != nil && retry > 0 {
+				req.Body = io.NopCloser(bytes.NewBuffer(body))
 			}
-		} else if res.StatusCode >= http.StatusInternalServerError && attempt < maxRetries {
-			time.Sleep(backoff)
-			setBody(req, body)
-			attempt++
-			backoff = backoff * backoff
-			return s.send(req, attempt, backoff)
-		} else {
-			var errRes map[string]interface{}
-			if err := Decode(res.Body, &errRes); err != nil {
-				return nil, fmt.Errorf("malformed error response, status code: %d", res.StatusCode)
+
+			// Try the request
+			if res, err = s.http.Do(req); err != nil {
+				// client error
+				return nil, err
+			} else if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusBadRequest {
+				// Error response code handling
+				// See official Retry guidance (https://learn.microsoft.com/en-us/azure/architecture/best-practices/retry-service-specific#retry-usage-guidance)
+				if res.StatusCode == http.StatusTooManyRequests {
+					retryAfterHeader := res.Header.Get("Retry-After")
+					if retryAfter, err := strconv.ParseInt(retryAfterHeader, 10, 64); err != nil {
+						return nil, fmt.Errorf("attempting to handle 429 but unable to parse retry-after header: %w", err)
+					} else {
+						// Wait the time indicated in the retry-after header
+						time.Sleep(time.Second * time.Duration(retryAfter))
+						continue
+					}
+				} else if res.StatusCode >= http.StatusInternalServerError {
+					// Wait the time calculated by the 5 second exponential backoff
+					backoff := math.Pow(5, float64(retry+1))
+					time.Sleep(time.Second * time.Duration(backoff))
+					continue
+				} else {
+					// Not a status code that warrants a retry
+					var errRes map[string]interface{}
+					if err := Decode(res.Body, &errRes); err != nil {
+						err = fmt.Errorf("malformed error response, status code: %d", res.StatusCode)
+					} else {
+						err = fmt.Errorf("%v", errRes)
+					}
+				}
 			} else {
-				return nil, fmt.Errorf("Error: %v", errRes)
+				// Response OK
+				return res, nil
 			}
 		}
-	} else {
-		return res, nil
+		return nil, fmt.Errorf("unable to complete the request after %d attempts: %w", maxRetries, err)
 	}
 }

--- a/client/rest/client.go
+++ b/client/rest/client.go
@@ -276,11 +276,10 @@ func (s *restClient) send(req *http.Request) (*http.Response, error) {
 					// Not a status code that warrants a retry
 					var errRes map[string]interface{}
 					if err := Decode(res.Body, &errRes); err != nil {
-						err = fmt.Errorf("malformed error response, status code: %d", res.StatusCode)
+						return nil, fmt.Errorf("malformed error response, status code: %d", res.StatusCode)
 					} else {
-						err = fmt.Errorf("%v", errRes)
+						return nil, fmt.Errorf("%v", errRes)
 					}
-					break
 				}
 			} else {
 				// Response OK

--- a/client/rest/client.go
+++ b/client/rest/client.go
@@ -280,6 +280,7 @@ func (s *restClient) send(req *http.Request) (*http.Response, error) {
 					} else {
 						err = fmt.Errorf("%v", errRes)
 					}
+					break
 				}
 			} else {
 				// Response OK


### PR DESCRIPTION
Implements the [retry guidance from Microsoft](https://learn.microsoft.com/en-us/azure/architecture/best-practices/retry-service-specific#retry-usage-guidance)

- For 429 errors, only retry after the time indicated in the Retry-After header.
- For 5xx errors, use exponential back-off, with the first retry at least 5 seconds after the response.
- Do not retry on errors other than 429 and 5xx.

Resolves #7