### PR TITLE
Improved context when exiting with error

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -58,7 +58,7 @@ var configureCmd = &cobra.Command{
 
 func configureCmdImpl(cmd *cobra.Command, args []string) {
 	if err := configure(); err != nil {
-		exit(err)
+		exit(fmt.Errorf("failed to configure cobra CLI: %w", err))
 	}
 }
 

--- a/cmd/install_windows.go
+++ b/cmd/install_windows.go
@@ -60,9 +60,9 @@ func installCmdImpl(cmd *cobra.Command, args []string) {
 	)
 
 	if err := configureService(); err != nil {
-		exit(err)
+		exit(fmt.Errorf("failed to configure service: %w", err))
 	} else if err := installService(constants.DisplayName, config, recoveryActions); err != nil {
-		exit(err)
+		exit(fmt.Errorf("failed to install service: %w", err))
 	}
 }
 

--- a/cmd/list-app-owners.go
+++ b/cmd/list-app-owners.go
@@ -48,18 +48,13 @@ func listAppOwnersCmdImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure app owners...")
-		start := time.Now()
-		stream := listAppOwners(ctx, azClient, listApps(ctx, azClient))
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure app owners...")
+	start := time.Now()
+	stream := listAppOwners(ctx, azClient, listApps(ctx, azClient))
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listAppOwners(ctx context.Context, client client.AzureClient, apps <-chan interface{}) <-chan interface{} {

--- a/cmd/list-app-role-assignments.go
+++ b/cmd/list-app-role-assignments.go
@@ -48,19 +48,14 @@ func listAppRoleAssignmentsCmdImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure active directory app role assignments...")
-		start := time.Now()
-		servicePrincipals := listServicePrincipals(ctx, azClient)
-		stream := listAppRoleAssignments(ctx, azClient, servicePrincipals)
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure active directory app role assignments...")
+	start := time.Now()
+	servicePrincipals := listServicePrincipals(ctx, azClient)
+	stream := listAppRoleAssignments(ctx, azClient, servicePrincipals)
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listAppRoleAssignments(ctx context.Context, client client.AzureClient, servicePrincipals <-chan interface{}) <-chan interface{} {

--- a/cmd/list-apps.go
+++ b/cmd/list-apps.go
@@ -45,18 +45,13 @@ func listAppsCmdImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure active directory applications...")
-		start := time.Now()
-		stream := listApps(ctx, azClient)
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure active directory applications...")
+	start := time.Now()
+	stream := listApps(ctx, azClient)
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listApps(ctx context.Context, client client.AzureClient) <-chan interface{} {

--- a/cmd/list-automation-account-role-assignments.go
+++ b/cmd/list-automation-account-role-assignments.go
@@ -49,19 +49,14 @@ func listAutomationAccountRoleAssignmentImpl(cmd *cobra.Command, args []string) 
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure automation account role assignments...")
-		start := time.Now()
-		subscriptions := listSubscriptions(ctx, azClient)
-		stream := listAutomationAccountRoleAssignments(ctx, azClient, listAutomationAccounts(ctx, azClient, subscriptions))
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure automation account role assignments...")
+	start := time.Now()
+	subscriptions := listSubscriptions(ctx, azClient)
+	stream := listAutomationAccountRoleAssignments(ctx, azClient, listAutomationAccounts(ctx, azClient, subscriptions))
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listAutomationAccountRoleAssignments(ctx context.Context, client client.AzureClient, automationAccounts <-chan interface{}) <-chan interface{} {

--- a/cmd/list-automation-accounts.go
+++ b/cmd/list-automation-accounts.go
@@ -48,18 +48,13 @@ func listAutomationAccountsCmdImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure automation accounts...")
-		start := time.Now()
-		stream := listAutomationAccounts(ctx, azClient, listSubscriptions(ctx, azClient))
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure automation accounts...")
+	start := time.Now()
+	stream := listAutomationAccounts(ctx, azClient, listSubscriptions(ctx, azClient))
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listAutomationAccounts(ctx context.Context, client client.AzureClient, subscriptions <-chan interface{}) <-chan interface{} {

--- a/cmd/list-azure-ad.go
+++ b/cmd/list-azure-ad.go
@@ -50,18 +50,13 @@ func listAzureADCmdImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure ad objects...")
-		start := time.Now()
-		stream := listAllAD(ctx, azClient)
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure ad objects...")
+	start := time.Now()
+	stream := listAllAD(ctx, azClient)
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listAllAD(ctx context.Context, client client.AzureClient) <-chan interface{} {

--- a/cmd/list-azure-rm.go
+++ b/cmd/list-azure-rm.go
@@ -52,18 +52,13 @@ func listAzureRMCmdImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure resource management objects...")
-		start := time.Now()
-		stream := listAllRM(ctx, azClient)
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure resource management objects...")
+	start := time.Now()
+	stream := listAllRM(ctx, azClient)
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listAllRM(ctx context.Context, client client.AzureClient) <-chan interface{} {

--- a/cmd/list-device-owners.go
+++ b/cmd/list-device-owners.go
@@ -48,18 +48,13 @@ func listDeviceOwnersCmdImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure device owners...")
-		start := time.Now()
-		stream := listDeviceOwners(ctx, azClient, listDevices(ctx, azClient))
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure device owners...")
+	start := time.Now()
+	stream := listDeviceOwners(ctx, azClient, listDevices(ctx, azClient))
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listDeviceOwners(ctx context.Context, client client.AzureClient, devices <-chan interface{}) <-chan interface{} {

--- a/cmd/list-devices.go
+++ b/cmd/list-devices.go
@@ -45,18 +45,13 @@ func listDevicesCmdImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure active directory devices...")
-		start := time.Now()
-		stream := listDevices(ctx, azClient)
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure active directory devices...")
+	start := time.Now()
+	stream := listDevices(ctx, azClient)
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listDevices(ctx context.Context, client client.AzureClient) <-chan interface{} {

--- a/cmd/list-function-app-role-assignments.go
+++ b/cmd/list-function-app-role-assignments.go
@@ -49,19 +49,14 @@ func listFunctionAppRoleAssignmentImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure function app role assignments...")
-		start := time.Now()
-		subscriptions := listSubscriptions(ctx, azClient)
-		stream := listFunctionAppRoleAssignments(ctx, azClient, listFunctionApps(ctx, azClient, subscriptions))
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure function app role assignments...")
+	start := time.Now()
+	subscriptions := listSubscriptions(ctx, azClient)
+	stream := listFunctionAppRoleAssignments(ctx, azClient, listFunctionApps(ctx, azClient, subscriptions))
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listFunctionAppRoleAssignments(ctx context.Context, client client.AzureClient, functionApps <-chan interface{}) <-chan interface{} {

--- a/cmd/list-function-apps.go
+++ b/cmd/list-function-apps.go
@@ -48,18 +48,13 @@ func listFunctionAppsCmdImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure function apps...")
-		start := time.Now()
-		stream := listFunctionApps(ctx, azClient, listSubscriptions(ctx, azClient))
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure function apps...")
+	start := time.Now()
+	stream := listFunctionApps(ctx, azClient, listSubscriptions(ctx, azClient))
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listFunctionApps(ctx context.Context, client client.AzureClient, subscriptions <-chan interface{}) <-chan interface{} {

--- a/cmd/list-group-members.go
+++ b/cmd/list-group-members.go
@@ -48,18 +48,13 @@ func listGroupMembersCmdImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure group members...")
-		start := time.Now()
-		stream := listGroupMembers(ctx, azClient, listGroups(ctx, azClient))
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure group members...")
+	start := time.Now()
+	stream := listGroupMembers(ctx, azClient, listGroups(ctx, azClient))
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listGroupMembers(ctx context.Context, client client.AzureClient, groups <-chan interface{}) <-chan interface{} {

--- a/cmd/list-group-owners.go
+++ b/cmd/list-group-owners.go
@@ -48,18 +48,13 @@ func listGroupOwnersCmdImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure group owners...")
-		start := time.Now()
-		stream := listGroupOwners(ctx, azClient, listGroups(ctx, azClient))
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure group owners...")
+	start := time.Now()
+	stream := listGroupOwners(ctx, azClient, listGroups(ctx, azClient))
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listGroupOwners(ctx context.Context, client client.AzureClient, groups <-chan interface{}) <-chan interface{} {

--- a/cmd/list-groups.go
+++ b/cmd/list-groups.go
@@ -45,18 +45,13 @@ func listGroupsCmdImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure active directory groups...")
-		start := time.Now()
-		stream := listGroups(ctx, azClient)
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure active directory groups...")
+	start := time.Now()
+	stream := listGroups(ctx, azClient)
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listGroups(ctx context.Context, client client.AzureClient) <-chan interface{} {

--- a/cmd/list-key-vault-access-policies_test.go
+++ b/cmd/list-key-vault-access-policies_test.go
@@ -50,7 +50,7 @@ func TestListKeyVaultAccessPolicies(t *testing.T) {
 				KeyVault: azure.KeyVault{
 					Properties: azure.VaultProperties{
 						AccessPolicies: []azure.AccessPolicyEntry{
-							azure.AccessPolicyEntry{
+							{
 								Permissions: azure.KeyVaultPermissions{
 									Certificates: []string{"Get"},
 								},

--- a/cmd/list-key-vault-kvcontributors.go
+++ b/cmd/list-key-vault-kvcontributors.go
@@ -47,21 +47,16 @@ func listKeyVaultKVContributorsCmdImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure key vault kvcontributors...")
-		start := time.Now()
-		subscriptions := listSubscriptions(ctx, azClient)
-		keyVaults := listKeyVaults(ctx, azClient, subscriptions)
-		kvRoleAssignments := listKeyVaultRoleAssignments(ctx, azClient, keyVaults)
-		stream := listKeyVaultKVContributors(ctx, kvRoleAssignments)
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure key vault kvcontributors...")
+	start := time.Now()
+	subscriptions := listSubscriptions(ctx, azClient)
+	keyVaults := listKeyVaults(ctx, azClient, subscriptions)
+	kvRoleAssignments := listKeyVaultRoleAssignments(ctx, azClient, keyVaults)
+	stream := listKeyVaultKVContributors(ctx, kvRoleAssignments)
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listKeyVaultKVContributors(

--- a/cmd/list-key-vault-owners.go
+++ b/cmd/list-key-vault-owners.go
@@ -47,21 +47,16 @@ func listKeyVaultOwnersCmdImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure key vault owners...")
-		start := time.Now()
-		subscriptions := listSubscriptions(ctx, azClient)
-		keyVaults := listKeyVaults(ctx, azClient, subscriptions)
-		kvRoleAssignments := listKeyVaultRoleAssignments(ctx, azClient, keyVaults)
-		stream := listKeyVaultOwners(ctx, kvRoleAssignments)
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure key vault owners...")
+	start := time.Now()
+	subscriptions := listSubscriptions(ctx, azClient)
+	keyVaults := listKeyVaults(ctx, azClient, subscriptions)
+	kvRoleAssignments := listKeyVaultRoleAssignments(ctx, azClient, keyVaults)
+	stream := listKeyVaultOwners(ctx, kvRoleAssignments)
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listKeyVaultOwners(

--- a/cmd/list-key-vault-role-assignments.go
+++ b/cmd/list-key-vault-role-assignments.go
@@ -48,19 +48,14 @@ func listKeyVaultRoleAssignmentsCmdImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure key vault role assignments...")
-		start := time.Now()
-		subscriptions := listSubscriptions(ctx, azClient)
-		stream := listKeyVaultRoleAssignments(ctx, azClient, listKeyVaults(ctx, azClient, subscriptions))
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure key vault role assignments...")
+	start := time.Now()
+	subscriptions := listSubscriptions(ctx, azClient)
+	stream := listKeyVaultRoleAssignments(ctx, azClient, listKeyVaults(ctx, azClient, subscriptions))
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listKeyVaultRoleAssignments(ctx context.Context, client client.AzureClient, keyVaults <-chan interface{}) <-chan azureWrapper[models.KeyVaultRoleAssignments] {

--- a/cmd/list-key-vault-user-access-admins.go
+++ b/cmd/list-key-vault-user-access-admins.go
@@ -47,21 +47,16 @@ func listKeyVaultUserAccessAdminsCmdImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure key vault user access admins...")
-		start := time.Now()
-		subscriptions := listSubscriptions(ctx, azClient)
-		keyVaults := listKeyVaults(ctx, azClient, subscriptions)
-		kvRoleAssignments := listKeyVaultRoleAssignments(ctx, azClient, keyVaults)
-		stream := listKeyVaultUserAccessAdmins(ctx, kvRoleAssignments)
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure key vault user access admins...")
+	start := time.Now()
+	subscriptions := listSubscriptions(ctx, azClient)
+	keyVaults := listKeyVaults(ctx, azClient, subscriptions)
+	kvRoleAssignments := listKeyVaultRoleAssignments(ctx, azClient, keyVaults)
+	stream := listKeyVaultUserAccessAdmins(ctx, kvRoleAssignments)
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listKeyVaultUserAccessAdmins(

--- a/cmd/list-key-vaults.go
+++ b/cmd/list-key-vaults.go
@@ -48,18 +48,13 @@ func listKeyVaultsCmdImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure key vaults...")
-		start := time.Now()
-		stream := listKeyVaults(ctx, azClient, listSubscriptions(ctx, azClient))
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure key vaults...")
+	start := time.Now()
+	stream := listKeyVaults(ctx, azClient, listSubscriptions(ctx, azClient))
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listKeyVaults(ctx context.Context, client client.AzureClient, subscriptions <-chan interface{}) <-chan interface{} {

--- a/cmd/list-management-group-descendants.go
+++ b/cmd/list-management-group-descendants.go
@@ -48,18 +48,13 @@ func listManagementGroupDescendantsCmdImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure management group descendants...")
-		start := time.Now()
-		stream := listManagementGroupDescendants(ctx, azClient, listManagementGroups(ctx, azClient))
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure management group descendants...")
+	start := time.Now()
+	stream := listManagementGroupDescendants(ctx, azClient, listManagementGroups(ctx, azClient))
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listManagementGroupDescendants(ctx context.Context, client client.AzureClient, managementGroups <-chan interface{}) <-chan interface{} {

--- a/cmd/list-management-group-owners.go
+++ b/cmd/list-management-group-owners.go
@@ -47,20 +47,15 @@ func listManagementGroupOwnersCmdImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure management group owners...")
-		start := time.Now()
-		managementGroups := listManagementGroups(ctx, azClient)
-		roleAssignments := listManagementGroupRoleAssignments(ctx, azClient, managementGroups)
-		stream := listManagementGroupOwners(ctx, roleAssignments)
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure management group owners...")
+	start := time.Now()
+	managementGroups := listManagementGroups(ctx, azClient)
+	roleAssignments := listManagementGroupRoleAssignments(ctx, azClient, managementGroups)
+	stream := listManagementGroupOwners(ctx, roleAssignments)
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listManagementGroupOwners(

--- a/cmd/list-management-group-role-assignments.go
+++ b/cmd/list-management-group-role-assignments.go
@@ -48,19 +48,14 @@ func listManagementGroupRoleAssignmentsCmdImpl(cmd *cobra.Command, args []string
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure management group role assignments...")
-		start := time.Now()
-		managementGroups := listManagementGroups(ctx, azClient)
-		stream := listManagementGroupRoleAssignments(ctx, azClient, managementGroups)
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure management group role assignments...")
+	start := time.Now()
+	managementGroups := listManagementGroups(ctx, azClient)
+	stream := listManagementGroupRoleAssignments(ctx, azClient, managementGroups)
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listManagementGroupRoleAssignments(ctx context.Context, client client.AzureClient, managementGroups <-chan interface{}) <-chan azureWrapper[models.ManagementGroupRoleAssignments] {

--- a/cmd/list-management-group-user-access-admins.go
+++ b/cmd/list-management-group-user-access-admins.go
@@ -47,20 +47,15 @@ func listManagementGroupUserAccessAdminsCmdImpl(cmd *cobra.Command, args []strin
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure management group user access admins...")
-		start := time.Now()
-		managementGroups := listManagementGroups(ctx, azClient)
-		roleAssignments := listManagementGroupRoleAssignments(ctx, azClient, managementGroups)
-		stream := listManagementGroupUserAccessAdmins(ctx, roleAssignments)
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure management group user access admins...")
+	start := time.Now()
+	managementGroups := listManagementGroups(ctx, azClient)
+	roleAssignments := listManagementGroupRoleAssignments(ctx, azClient, managementGroups)
+	stream := listManagementGroupUserAccessAdmins(ctx, roleAssignments)
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listManagementGroupUserAccessAdmins(

--- a/cmd/list-management-groups.go
+++ b/cmd/list-management-groups.go
@@ -46,18 +46,13 @@ func listManagementGroupsCmdImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure active directory management groups...")
-		start := time.Now()
-		stream := listManagementGroups(ctx, azClient)
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure active directory management groups...")
+	start := time.Now()
+	stream := listManagementGroups(ctx, azClient)
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listManagementGroups(ctx context.Context, client client.AzureClient) <-chan interface{} {

--- a/cmd/list-resource-group-owners.go
+++ b/cmd/list-resource-group-owners.go
@@ -47,21 +47,16 @@ func listResourceGroupOwnersCmdImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure resource group owners...")
-		start := time.Now()
-		subscriptions := listSubscriptions(ctx, azClient)
-		resourceGroups := listResourceGroups(ctx, azClient, subscriptions)
-		roleAssignments := listResourceGroupRoleAssignments(ctx, azClient, resourceGroups)
-		stream := listResourceGroupOwners(ctx, roleAssignments)
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure resource group owners...")
+	start := time.Now()
+	subscriptions := listSubscriptions(ctx, azClient)
+	resourceGroups := listResourceGroups(ctx, azClient, subscriptions)
+	roleAssignments := listResourceGroupRoleAssignments(ctx, azClient, resourceGroups)
+	stream := listResourceGroupOwners(ctx, roleAssignments)
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listResourceGroupOwners(

--- a/cmd/list-resource-group-role-assignments.go
+++ b/cmd/list-resource-group-role-assignments.go
@@ -48,20 +48,15 @@ func listResourceGroupRoleAssignmentsCmdImpl(cmd *cobra.Command, args []string) 
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure resource group role assignments...")
-		start := time.Now()
-		subscriptions := listSubscriptions(ctx, azClient)
-		resourceGroups := listResourceGroups(ctx, azClient, subscriptions)
-		stream := listResourceGroupRoleAssignments(ctx, azClient, resourceGroups)
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure resource group role assignments...")
+	start := time.Now()
+	subscriptions := listSubscriptions(ctx, azClient)
+	resourceGroups := listResourceGroups(ctx, azClient, subscriptions)
+	stream := listResourceGroupRoleAssignments(ctx, azClient, resourceGroups)
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listResourceGroupRoleAssignments(ctx context.Context, client client.AzureClient, resourceGroups <-chan interface{}) <-chan azureWrapper[models.ResourceGroupRoleAssignments] {

--- a/cmd/list-resource-group-user-access-admins.go
+++ b/cmd/list-resource-group-user-access-admins.go
@@ -47,21 +47,16 @@ func listResourceGroupUserAccessAdminsCmdImpl(cmd *cobra.Command, args []string)
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure resource group user access admins...")
-		start := time.Now()
-		subscriptions := listSubscriptions(ctx, azClient)
-		resourceGroups := listResourceGroups(ctx, azClient, subscriptions)
-		roleAssignments := listResourceGroupRoleAssignments(ctx, azClient, resourceGroups)
-		stream := listResourceGroupUserAccessAdmins(ctx, roleAssignments)
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure resource group user access admins...")
+	start := time.Now()
+	subscriptions := listSubscriptions(ctx, azClient)
+	resourceGroups := listResourceGroups(ctx, azClient, subscriptions)
+	roleAssignments := listResourceGroupRoleAssignments(ctx, azClient, resourceGroups)
+	stream := listResourceGroupUserAccessAdmins(ctx, roleAssignments)
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listResourceGroupUserAccessAdmins(

--- a/cmd/list-resource-groups.go
+++ b/cmd/list-resource-groups.go
@@ -48,18 +48,13 @@ func listResourceGroupsCmdImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure resource groups...")
-		start := time.Now()
-		stream := listResourceGroups(ctx, azClient, listSubscriptions(ctx, azClient))
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure resource groups...")
+	start := time.Now()
+	stream := listResourceGroups(ctx, azClient, listSubscriptions(ctx, azClient))
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listResourceGroups(ctx context.Context, client client.AzureClient, subscriptions <-chan interface{}) <-chan interface{} {

--- a/cmd/list-role-assignments.go
+++ b/cmd/list-role-assignments.go
@@ -48,19 +48,14 @@ func listRoleAssignmentsCmdImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure active directory role assignments...")
-		start := time.Now()
-		roles := listRoles(ctx, azClient)
-		stream := listRoleAssignments(ctx, azClient, roles)
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure active directory role assignments...")
+	start := time.Now()
+	roles := listRoles(ctx, azClient)
+	stream := listRoleAssignments(ctx, azClient, roles)
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listRoleAssignments(ctx context.Context, client client.AzureClient, roles <-chan interface{}) <-chan interface{} {

--- a/cmd/list-roles.go
+++ b/cmd/list-roles.go
@@ -45,18 +45,13 @@ func listRolesCmdImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure active directory roles...")
-		start := time.Now()
-		stream := listRoles(ctx, azClient)
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure active directory roles...")
+	start := time.Now()
+	stream := listRoles(ctx, azClient)
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listRoles(ctx context.Context, client client.AzureClient) <-chan interface{} {

--- a/cmd/list-root.go
+++ b/cmd/list-root.go
@@ -52,18 +52,13 @@ func listCmdImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure objects...")
-		start := time.Now()
-		stream := listAll(ctx, azClient)
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure objects...")
+	start := time.Now()
+	stream := listAll(ctx, azClient)
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listAll(ctx context.Context, client client.AzureClient) <-chan interface{} {

--- a/cmd/list-service-principal-owners.go
+++ b/cmd/list-service-principal-owners.go
@@ -48,18 +48,13 @@ func listServicePrincipalOwnersCmdImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure service principal owners...")
-		start := time.Now()
-		stream := listServicePrincipalOwners(ctx, azClient, listServicePrincipals(ctx, azClient))
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure service principal owners...")
+	start := time.Now()
+	stream := listServicePrincipalOwners(ctx, azClient, listServicePrincipals(ctx, azClient))
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listServicePrincipalOwners(ctx context.Context, client client.AzureClient, servicePrincipals <-chan interface{}) <-chan interface{} {

--- a/cmd/list-service-principals.go
+++ b/cmd/list-service-principals.go
@@ -45,18 +45,13 @@ func listServicePrincipalsCmdImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure active directory service principals...")
-		start := time.Now()
-		stream := listServicePrincipals(ctx, azClient)
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure active directory service principals...")
+	start := time.Now()
+	stream := listServicePrincipals(ctx, azClient)
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listServicePrincipals(ctx context.Context, client client.AzureClient) <-chan interface{} {

--- a/cmd/list-storage-account-role-assignments.go
+++ b/cmd/list-storage-account-role-assignments.go
@@ -49,19 +49,14 @@ func listStorageAccountRoleAssignmentsImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure storage account role assignments...")
-		start := time.Now()
-		subscriptions := listSubscriptions(ctx, azClient)
-		stream := listStorageAccountRoleAssignments(ctx, azClient, listStorageAccounts(ctx, azClient, subscriptions))
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure storage account role assignments...")
+	start := time.Now()
+	subscriptions := listSubscriptions(ctx, azClient)
+	stream := listStorageAccountRoleAssignments(ctx, azClient, listStorageAccounts(ctx, azClient, subscriptions))
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listStorageAccountRoleAssignments(ctx context.Context, client client.AzureClient, storageAccounts <-chan interface{}) <-chan interface{} {

--- a/cmd/list-storage-accounts.go
+++ b/cmd/list-storage-accounts.go
@@ -48,18 +48,13 @@ func listStorageAccountsCmdImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure storage accounts...")
-		start := time.Now()
-		stream := listStorageAccounts(ctx, azClient, listSubscriptions(ctx, azClient))
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure storage accounts...")
+	start := time.Now()
+	stream := listStorageAccounts(ctx, azClient, listSubscriptions(ctx, azClient))
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listStorageAccounts(ctx context.Context, client client.AzureClient, subscriptions <-chan interface{}) <-chan interface{} {

--- a/cmd/list-subscription-owners.go
+++ b/cmd/list-subscription-owners.go
@@ -49,20 +49,15 @@ func listSubscriptionOwnersCmdImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure subscription owners...")
-		start := time.Now()
-		subscriptions := listSubscriptions(ctx, azClient)
-		roleAssignments := listSubscriptionRoleAssignments(ctx, azClient, subscriptions)
-		stream := listSubscriptionOwners(ctx, azClient, roleAssignments)
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure subscription owners...")
+	start := time.Now()
+	subscriptions := listSubscriptions(ctx, azClient)
+	roleAssignments := listSubscriptionRoleAssignments(ctx, azClient, subscriptions)
+	stream := listSubscriptionOwners(ctx, azClient, roleAssignments)
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listSubscriptionOwners(ctx context.Context, client client.AzureClient, roleAssignments <-chan interface{}) <-chan interface{} {

--- a/cmd/list-subscription-role-assignments.go
+++ b/cmd/list-subscription-role-assignments.go
@@ -48,19 +48,14 @@ func listSubscriptionRoleAssignmentsCmdImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure subscription role assignments...")
-		start := time.Now()
-		subscriptions := listSubscriptions(ctx, azClient)
-		stream := listSubscriptionRoleAssignments(ctx, azClient, subscriptions)
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure subscription role assignments...")
+	start := time.Now()
+	subscriptions := listSubscriptions(ctx, azClient)
+	stream := listSubscriptionRoleAssignments(ctx, azClient, subscriptions)
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listSubscriptionRoleAssignments(ctx context.Context, client client.AzureClient, subscriptions <-chan interface{}) <-chan interface{} {

--- a/cmd/list-subscription-user-access-admins.go
+++ b/cmd/list-subscription-user-access-admins.go
@@ -49,20 +49,15 @@ func listSubscriptionUserAccessAdminsCmdImpl(cmd *cobra.Command, args []string) 
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure subscription user access admins...")
-		start := time.Now()
-		subscriptions := listSubscriptions(ctx, azClient)
-		roleAssignments := listSubscriptionRoleAssignments(ctx, azClient, subscriptions)
-		stream := listSubscriptionUserAccessAdmins(ctx, azClient, roleAssignments)
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure subscription user access admins...")
+	start := time.Now()
+	subscriptions := listSubscriptions(ctx, azClient)
+	roleAssignments := listSubscriptionRoleAssignments(ctx, azClient, subscriptions)
+	stream := listSubscriptionUserAccessAdmins(ctx, azClient, roleAssignments)
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listSubscriptionUserAccessAdmins(ctx context.Context, client client.AzureClient, vmRoleAssignments <-chan interface{}) <-chan interface{} {

--- a/cmd/list-subscriptions.go
+++ b/cmd/list-subscriptions.go
@@ -49,18 +49,13 @@ func listSubscriptionsCmdImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure active directory subscriptions...")
-		start := time.Now()
-		stream := listSubscriptions(ctx, azClient)
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure active directory subscriptions...")
+	start := time.Now()
+	stream := listSubscriptions(ctx, azClient)
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listSubscriptions(ctx context.Context, client client.AzureClient) <-chan interface{} {

--- a/cmd/list-tenants.go
+++ b/cmd/list-tenants.go
@@ -45,18 +45,13 @@ func listTenantsCmdImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure active directory tenants...")
-		start := time.Now()
-		stream := listTenants(ctx, azClient)
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure active directory tenants...")
+	start := time.Now()
+	stream := listTenants(ctx, azClient)
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listTenants(ctx context.Context, client client.AzureClient) <-chan interface{} {

--- a/cmd/list-users.go
+++ b/cmd/list-users.go
@@ -45,18 +45,13 @@ func listUsersCmdImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure active directory users...")
-		start := time.Now()
-		stream := listUsers(ctx, azClient)
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure active directory users...")
+	start := time.Now()
+	stream := listUsers(ctx, azClient)
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listUsers(ctx context.Context, client client.AzureClient) <-chan interface{} {

--- a/cmd/list-virtual-machine-admin-logins.go
+++ b/cmd/list-virtual-machine-admin-logins.go
@@ -47,21 +47,16 @@ func listVirtualMachineAdminLoginsCmdImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure virtual machine admin logins...")
-		start := time.Now()
-		subscriptions := listSubscriptions(ctx, azClient)
-		vms := listVirtualMachines(ctx, azClient, subscriptions)
-		vmRoleAssignments := listVirtualMachineRoleAssignments(ctx, azClient, vms)
-		stream := listVirtualMachineAdminLogins(ctx, vmRoleAssignments)
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure virtual machine admin logins...")
+	start := time.Now()
+	subscriptions := listSubscriptions(ctx, azClient)
+	vms := listVirtualMachines(ctx, azClient, subscriptions)
+	vmRoleAssignments := listVirtualMachineRoleAssignments(ctx, azClient, vms)
+	stream := listVirtualMachineAdminLogins(ctx, vmRoleAssignments)
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listVirtualMachineAdminLogins(

--- a/cmd/list-virtual-machine-avere-contributors.go
+++ b/cmd/list-virtual-machine-avere-contributors.go
@@ -47,21 +47,16 @@ func listVirtualMachineAvereContributorsCmdImpl(cmd *cobra.Command, args []strin
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure virtual machine averecontributors...")
-		start := time.Now()
-		subscriptions := listSubscriptions(ctx, azClient)
-		vms := listVirtualMachines(ctx, azClient, subscriptions)
-		vmRoleAssignments := listVirtualMachineRoleAssignments(ctx, azClient, vms)
-		stream := listVirtualMachineAvereContributors(ctx, vmRoleAssignments)
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure virtual machine averecontributors...")
+	start := time.Now()
+	subscriptions := listSubscriptions(ctx, azClient)
+	vms := listVirtualMachines(ctx, azClient, subscriptions)
+	vmRoleAssignments := listVirtualMachineRoleAssignments(ctx, azClient, vms)
+	stream := listVirtualMachineAvereContributors(ctx, vmRoleAssignments)
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listVirtualMachineAvereContributors(

--- a/cmd/list-virtual-machine-contributors.go
+++ b/cmd/list-virtual-machine-contributors.go
@@ -47,21 +47,16 @@ func listVirtualMachineContributorsCmdImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure virtual machine contributors...")
-		start := time.Now()
-		subscriptions := listSubscriptions(ctx, azClient)
-		vms := listVirtualMachines(ctx, azClient, subscriptions)
-		vmRoleAssignments := listVirtualMachineRoleAssignments(ctx, azClient, vms)
-		stream := listVirtualMachineContributors(ctx, vmRoleAssignments)
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure virtual machine contributors...")
+	start := time.Now()
+	subscriptions := listSubscriptions(ctx, azClient)
+	vms := listVirtualMachines(ctx, azClient, subscriptions)
+	vmRoleAssignments := listVirtualMachineRoleAssignments(ctx, azClient, vms)
+	stream := listVirtualMachineContributors(ctx, vmRoleAssignments)
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listVirtualMachineContributors(

--- a/cmd/list-virtual-machine-owners.go
+++ b/cmd/list-virtual-machine-owners.go
@@ -47,21 +47,16 @@ func listVirtualMachineOwnersCmdImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure virtual machine owners...")
-		start := time.Now()
-		subscriptions := listSubscriptions(ctx, azClient)
-		vms := listVirtualMachines(ctx, azClient, subscriptions)
-		vmRoleAssignments := listVirtualMachineRoleAssignments(ctx, azClient, vms)
-		stream := listVirtualMachineOwners(ctx, vmRoleAssignments)
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure virtual machine owners...")
+	start := time.Now()
+	subscriptions := listSubscriptions(ctx, azClient)
+	vms := listVirtualMachines(ctx, azClient, subscriptions)
+	vmRoleAssignments := listVirtualMachineRoleAssignments(ctx, azClient, vms)
+	stream := listVirtualMachineOwners(ctx, vmRoleAssignments)
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listVirtualMachineOwners(

--- a/cmd/list-virtual-machine-role-assignments.go
+++ b/cmd/list-virtual-machine-role-assignments.go
@@ -48,19 +48,14 @@ func listVirtualMachineRoleAssignmentsCmdImpl(cmd *cobra.Command, args []string)
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure virtual machine role assignments...")
-		start := time.Now()
-		subscriptions := listSubscriptions(ctx, azClient)
-		stream := listVirtualMachineRoleAssignments(ctx, azClient, listVirtualMachines(ctx, azClient, subscriptions))
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure virtual machine role assignments...")
+	start := time.Now()
+	subscriptions := listSubscriptions(ctx, azClient)
+	stream := listVirtualMachineRoleAssignments(ctx, azClient, listVirtualMachines(ctx, azClient, subscriptions))
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listVirtualMachineRoleAssignments(ctx context.Context, client client.AzureClient, virtualMachines <-chan interface{}) <-chan azureWrapper[models.VirtualMachineRoleAssignments] {

--- a/cmd/list-virtual-machine-user-access-admins.go
+++ b/cmd/list-virtual-machine-user-access-admins.go
@@ -47,21 +47,16 @@ func listVirtualMachineUserAccessAdminsCmdImpl(cmd *cobra.Command, args []string
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure virtual machine user access admins...")
-		start := time.Now()
-		subscriptions := listSubscriptions(ctx, azClient)
-		vms := listVirtualMachines(ctx, azClient, subscriptions)
-		vmRoleAssignments := listVirtualMachineRoleAssignments(ctx, azClient, vms)
-		stream := listVirtualMachineUserAccessAdmins(ctx, vmRoleAssignments)
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure virtual machine user access admins...")
+	start := time.Now()
+	subscriptions := listSubscriptions(ctx, azClient)
+	vms := listVirtualMachines(ctx, azClient, subscriptions)
+	vmRoleAssignments := listVirtualMachineRoleAssignments(ctx, azClient, vms)
+	stream := listVirtualMachineUserAccessAdmins(ctx, vmRoleAssignments)
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listVirtualMachineUserAccessAdmins(

--- a/cmd/list-virtual-machine-vmcontributors.go
+++ b/cmd/list-virtual-machine-vmcontributors.go
@@ -47,21 +47,16 @@ func listVirtualMachineVMContributorsCmdImpl(cmd *cobra.Command, args []string) 
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure virtual machine vmcontributors...")
-		start := time.Now()
-		subscriptions := listSubscriptions(ctx, azClient)
-		vms := listVirtualMachines(ctx, azClient, subscriptions)
-		vmRoleAssignments := listVirtualMachineRoleAssignments(ctx, azClient, vms)
-		stream := listVirtualMachineVMContributors(ctx, vmRoleAssignments)
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure virtual machine vmcontributors...")
+	start := time.Now()
+	subscriptions := listSubscriptions(ctx, azClient)
+	vms := listVirtualMachines(ctx, azClient, subscriptions)
+	vmRoleAssignments := listVirtualMachineRoleAssignments(ctx, azClient, vms)
+	stream := listVirtualMachineVMContributors(ctx, vmRoleAssignments)
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listVirtualMachineVMContributors(

--- a/cmd/list-virtual-machines.go
+++ b/cmd/list-virtual-machines.go
@@ -48,18 +48,13 @@ func listVirtualMachinesCmdImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure virtual machines...")
-		start := time.Now()
-		stream := listVirtualMachines(ctx, azClient, listSubscriptions(ctx, azClient))
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure virtual machines...")
+	start := time.Now()
+	stream := listVirtualMachines(ctx, azClient, listSubscriptions(ctx, azClient))
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listVirtualMachines(ctx context.Context, client client.AzureClient, subscriptions <-chan interface{}) <-chan interface{} {

--- a/cmd/list-workflow-role-assignments.go
+++ b/cmd/list-workflow-role-assignments.go
@@ -49,19 +49,14 @@ func listWorkflowRoleAssignmentImpl(cmd *cobra.Command, args []string) {
 	defer gracefulShutdown(stop)
 
 	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure workflow role assignments...")
-		start := time.Now()
-		subscriptions := listSubscriptions(ctx, azClient)
-		stream := listWorkflowRoleAsignments(ctx, azClient, listWorkflows(ctx, azClient, subscriptions))
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure workflow role assignments...")
+	start := time.Now()
+	subscriptions := listSubscriptions(ctx, azClient)
+	stream := listWorkflowRoleAsignments(ctx, azClient, listWorkflows(ctx, azClient, subscriptions))
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listWorkflowRoleAsignments(ctx context.Context, client client.AzureClient, workflows <-chan interface{}) <-chan interface{} {

--- a/cmd/list-workflows.go
+++ b/cmd/list-workflows.go
@@ -47,19 +47,13 @@ func listWorkflowsCmdImpl(cmd *cobra.Command, args []string) {
 	ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, os.Kill)
 	defer gracefulShutdown(stop)
 
-	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(err)
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(err)
-	} else {
-		log.Info("collecting azure workflows...")
-		start := time.Now()
-		stream := listWorkflows(ctx, azClient, listSubscriptions(ctx, azClient))
-		outputStream(ctx, stream)
-		duration := time.Since(start)
-		log.Info("collection completed", "duration", duration.String())
-	}
+	azClient := connectAndCreateClient()
+	log.Info("collecting azure workflows...")
+	start := time.Now()
+	stream := listWorkflows(ctx, azClient, listSubscriptions(ctx, azClient))
+	outputStream(ctx, stream)
+	duration := time.Since(start)
+	log.Info("collection completed", "duration", duration.String())
 }
 
 func listWorkflows(ctx context.Context, client client.AzureClient, subscriptions <-chan interface{}) <-chan interface{} {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -30,7 +30,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/bloodhoundad/azurehound/client"
 	"github.com/bloodhoundad/azurehound/client/rest"
 	"github.com/bloodhoundad/azurehound/config"
 	"github.com/bloodhoundad/azurehound/constants"
@@ -125,7 +124,9 @@ func start(ctx context.Context) {
 								// Notify BHE instance of task start
 								currentTask = &executableTasks[0]
 								if err := startTask(ctx, *bheInstance, bheClient, currentTask.Id); err != nil {
-									log.Error(err, "failed to start task")
+									log.Error(err, "failed to start task, will retry on next heartbeat")
+									currentTask = nil
+									return
 								}
 
 								start := time.Now()
@@ -276,17 +277,4 @@ func updateClient(ctx context.Context, bheUrl url.URL, bheClient *http.Client) e
 			}
 		}
 	}
-}
-
-func connectAndCreateClient() client.AzureClient {
-	log.V(1).Info("testing connections")
-	if err := testConnections(); err != nil {
-		exit(fmt.Errorf("failed to test connections: %w", err))
-	} else if azClient, err := newAzureClient(); err != nil {
-		exit(fmt.Errorf("failed to create new Azure client: %w", err))
-	} else {
-		return azClient
-	}
-
-	panic("unexpectedly failed to create azClient without error")
 }

--- a/cmd/uninstall_windows.go
+++ b/cmd/uninstall_windows.go
@@ -18,6 +18,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/bloodhoundad/azurehound/constants"
 	"github.com/spf13/cobra"
 	"golang.org/x/sys/windows/svc/eventlog"
@@ -38,7 +40,7 @@ var uninstallCmd = &cobra.Command{
 
 func uninstallCmdImpl(cmd *cobra.Command, args []string) {
 	if err := uninstallService(constants.Name); err != nil {
-		exit(err)
+		exit(fmt.Errorf("failed to uninstall service: %w", err))
 	}
 }
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -395,7 +395,7 @@ func outputStream[T any](ctx context.Context, stream <-chan T) {
 	formatted := pipeline.FormatJson(ctx.Done(), stream)
 	if path := config.OutputFile.Value().(string); path != "" {
 		if err := sinks.WriteToFile(ctx, path, formatted); err != nil {
-			exit(err)
+			exit(fmt.Errorf("failed to write stream to file: %w", err))
 		}
 	} else {
 		sinks.WriteToConsole(ctx, formatted)

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -425,3 +425,16 @@ func mgmtGroupRoleAssignmentFilter(roleId string) func(models.ManagementGroupRol
 		return path.Base(ra.RoleAssignment.Properties.RoleDefinitionId) == roleId
 	}
 }
+
+func connectAndCreateClient() client.AzureClient {
+	log.V(1).Info("testing connections")
+	if err := testConnections(); err != nil {
+		exit(fmt.Errorf("failed to test connections: %w", err))
+	} else if azClient, err := newAzureClient(); err != nil {
+		exit(fmt.Errorf("failed to create new Azure client: %w", err))
+	} else {
+		return azClient
+	}
+
+	panic("unexpectedly failed to create azClient without error")
+}

--- a/models/azure/immutability_policy.go
+++ b/models/azure/immutability_policy.go
@@ -19,6 +19,6 @@ package azure
 
 type ImmutabilityPolicy struct {
 	Etag          string                       `json:"etag,omitempty"`
-	Properties    ImmutabilityPolicyProperties `json:properties`
+	Properties    ImmutabilityPolicyProperties `json:"properties"`
 	UpdateHistory ImmutablePolicyUpdateHistory `json:"updateHistory,omitempty"`
 }

--- a/models/azure/immutable_storage_with_versioning.go
+++ b/models/azure/immutable_storage_with_versioning.go
@@ -22,5 +22,5 @@ import "github.com/bloodhoundad/azurehound/enums"
 type ImmutableStorageWithVersioning struct {
 	Enabled        bool                 `json:"enabled,omitempty"`
 	MigrationState enums.MigrationState `json:"migrationState,omitempty"`
-	timeStamp      string               `json:"timeStamp,omitempty"`
+	TimeStamp      string               `json:"timeStamp,omitempty"`
 }

--- a/models/azure/site_config.go
+++ b/models/azure/site_config.go
@@ -20,18 +20,18 @@ package azure
 import "github.com/bloodhoundad/azurehound/enums"
 
 type SiteConfig struct {
-	AcrUseManagedIdentityCreds             bool                             `json:"acrUseManagedIdentityCreds,omitemtpy"`
-	AcrUserManagedIdentityID               string                           `json:"acrUserManagedIdentityID,omitemtpy"`
-	AlwaysOn                               bool                             `json:"alwaysOn,omitemtpy"`
-	ApiDefinition                          ApiDefinitionInfo                `json:"apiDefinition,omitemtpy"`
-	ApiManagementConfig                    ApiManagementConfig              `json:"apiManagementConfig,omitemtpy"`
-	AppCommandLine                         string                           `json:"appCommandLine,omitemtpy"`
-	AppSettings                            []NameValuePair                  `json:"appSettings,omitemtpy"`
-	AutoHealEnabled                        bool                             `json:"autoHealEnabled,omitemtpy"`
-	AutoHealRules                          string                           `json:"autoHealRules,omitemtpy"`
-	AutoSwapSlotName                       string                           `json:"autoSwapSlotName,omitemtpy"`
-	AzureStorageAccounts                   map[string]AzureStorageInfoValue `json:"azureStorageAccounts,omitemtpy"`
-	ConnectionStrings                      []ConnStringInfo                 `json:"connectionStrings,omitemtpy"`
+	AcrUseManagedIdentityCreds             bool                             `json:"acrUseManagedIdentityCreds,omitempty"`
+	AcrUserManagedIdentityID               string                           `json:"acrUserManagedIdentityID,omitempty"`
+	AlwaysOn                               bool                             `json:"alwaysOn,omitempty"`
+	ApiDefinition                          ApiDefinitionInfo                `json:"apiDefinition,omitempty"`
+	ApiManagementConfig                    ApiManagementConfig              `json:"apiManagementConfig,omitempty"`
+	AppCommandLine                         string                           `json:"appCommandLine,omitempty"`
+	AppSettings                            []NameValuePair                  `json:"appSettings,omitempty"`
+	AutoHealEnabled                        bool                             `json:"autoHealEnabled,omitempty"`
+	AutoHealRules                          string                           `json:"autoHealRules,omitempty"`
+	AutoSwapSlotName                       string                           `json:"autoSwapSlotName,omitempty"`
+	AzureStorageAccounts                   map[string]AzureStorageInfoValue `json:"azureStorageAccounts,omitempty"`
+	ConnectionStrings                      []ConnStringInfo                 `json:"connectionStrings,omitempty"`
 	Cors                                   CorsSettings                     `json:"cors,omitempty"`
 	DefaultDocuments                       []string                         `json:"defaultDocuments,omitempty"`
 	DetailedErrorLoggingEnabled            bool                             `json:"detailedErrorLoggingEnabled,omitempty"`
@@ -89,26 +89,26 @@ type SiteConfig struct {
 	XManagedServiceIdentityId              int                              `json:"xManagedServiceIdentityId,omitempty"`
 
 	//Following ones have been found in testing, but not present in the documentation
-	AntivirusScanEnabled                   bool        `json:"antivirusScanEnabled,omitemtpy"`
-	AzureMonitorLogCategories              interface{} `json:"azureMonitorLogCategories,omitemtpy"`
-	CustomAppPoolIdentityAdminState        interface{} `json:"customAppPoolIdentityAdminState,omitemtpy"`
-	CustomAppPoolIdentityTenantState       interface{} `json:"customAppPoolIdentityTenantState,omitemtpy"`
-	ElasticWebAppScaleLimit                interface{} `json:"elasticWebAppScaleLimit,omitemtpy"`
-	FileChangeAuditEnabled                 bool        `json:"fileChangeAuditEnabled,omitemtpy"`
-	Http20ProxyFlag                        interface{} `json:"http20ProxyFlag,omitemtpy"`
-	IpSecurityRestrictionsDefaultAction    interface{} `json:"ipSecurityRestrictionsDefaultAction,omitemtpy"`
-	Metadata                               interface{} `json:"metadata,omitemtpy"`
-	MinTlsCipherSuite                      interface{} `json:"minTlsCipherSuite,omitemtpy"`
-	PublishingPassword                     interface{} `json:"publishingPassword,omitemtpy"`
-	RoutingRules                           interface{} `json:"routingRules,omitemtpy"`
-	RuntimeADUser                          interface{} `json:"runtimeADUser,omitemtpy"`
-	RuntimeADUserPassword                  interface{} `json:"runtimeADUserPassword,omitemtpy"`
-	ScmIpSecurityRestrictionsDefaultAction interface{} `json:"scmIpSecurityRestrictionsDefaultAction,omitemtpy"`
-	SitePort                               interface{} `json:"sitePort,omitemtpy"`
-	StorageType                            interface{} `json:"storageType,omitemtpy"`
-	SupportedTlsCipherSuites               interface{} `json:"supportedTlsCipherSuites,omitemtpy"`
-	WinAuthAdminState                      interface{} `json:"winAuthAdminState,omitemtpy"`
-	WinAuthTenantState                     interface{} `json:"winAuthTenantState,omitemtpy"`
+	AntivirusScanEnabled                   bool        `json:"antivirusScanEnabled,omitempty"`
+	AzureMonitorLogCategories              interface{} `json:"azureMonitorLogCategories,omitempty"`
+	CustomAppPoolIdentityAdminState        interface{} `json:"customAppPoolIdentityAdminState,omitempty"`
+	CustomAppPoolIdentityTenantState       interface{} `json:"customAppPoolIdentityTenantState,omitempty"`
+	ElasticWebAppScaleLimit                interface{} `json:"elasticWebAppScaleLimit,omitempty"`
+	FileChangeAuditEnabled                 bool        `json:"fileChangeAuditEnabled,omitempty"`
+	Http20ProxyFlag                        interface{} `json:"http20ProxyFlag,omitempty"`
+	IpSecurityRestrictionsDefaultAction    interface{} `json:"ipSecurityRestrictionsDefaultAction,omitempty"`
+	Metadata                               interface{} `json:"metadata,omitempty"`
+	MinTlsCipherSuite                      interface{} `json:"minTlsCipherSuite,omitempty"`
+	PublishingPassword                     interface{} `json:"publishingPassword,omitempty"`
+	RoutingRules                           interface{} `json:"routingRules,omitempty"`
+	RuntimeADUser                          interface{} `json:"runtimeADUser,omitempty"`
+	RuntimeADUserPassword                  interface{} `json:"runtimeADUserPassword,omitempty"`
+	ScmIpSecurityRestrictionsDefaultAction interface{} `json:"scmIpSecurityRestrictionsDefaultAction,omitempty"`
+	SitePort                               interface{} `json:"sitePort,omitempty"`
+	StorageType                            interface{} `json:"storageType,omitempty"`
+	SupportedTlsCipherSuites               interface{} `json:"supportedTlsCipherSuites,omitempty"`
+	WinAuthAdminState                      interface{} `json:"winAuthAdminState,omitempty"`
+	WinAuthTenantState                     interface{} `json:"winAuthTenantState,omitempty"`
 }
 
 type ApiDefinitionInfo struct {

--- a/models/azure/workflow_definition.go
+++ b/models/azure/workflow_definition.go
@@ -30,7 +30,7 @@ type Definition struct {
 }
 
 type Action struct {
-	Type string `json:type`
+	Type string `json:"type"`
 	// Kind is missing in the MSDN, but returned and present in examples and during testing
 	Kind                 string                 `json:"kind,omitempty"`
 	Inputs               map[string]interface{} `json:"inputs,omitempty"`


### PR DESCRIPTION
fix: added context to every exit()
chore: refactored common connectionTest() and newAzureClient() calls into its own reusable function
chore: fixed a few linter issues, including two unhandled error cases
chore: added break if currentTask errors and updated log message
chore: fixed several instances of bad json tags that were flagged by go vet