### PR TITLE
Fix for Azure Service Principals who have no permission to access the Graph API

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -254,7 +254,7 @@ func newAzureClient() (client.AzureClient, error) {
 		Tenant:         config.AzTenant.Value().(string),
 		Username:       config.AzUsername.Value().(string),
 	}
-	return client.NewClient(config)
+	return client.NewClient(config, log)
 }
 
 func newSigningHttpClient(signature, tokenId, token, proxyUrl string) (*http.Client, error) {


### PR DESCRIPTION
Data collection with _azurehound_ does not work for Azure Service Principals who have no permission to access the Graph API because calling ``client.GetAzureADOrganization()`` fails. However, collecting information from the Azure Resource Manager is still possible.

This pull request implements a bugfix so that you can use commands like ``list az-rm`` with those Service Principals.

Sample output:

```
$ ./azurehound list az-rm -v 2 -a "[REDACTED]" --secret "[REDACTED]" -t "[REDACTED]" -o "az-rm.json" --log-file az-rm.log --json
AzureHound 2379ab55f4a5c12ed2cae977ab33a2d59f5a0192
Created by the BloodHound Enterprise team - https://bloodhoundenterprise.io

No configuration file located at [REDACTED]/.config/azurehound/config.json
{"level":"debug","time":"2023-05-05T16:49:27+02:00","message":"Log File: az-rm.log"}
{"level":"debug","time":"2023-05-05T16:49:27+02:00","message":"testing connections"}
{"level":"debug","time":"2023-05-05T16:49:27+02:00","message":"testing connections"}
{"level":"trace","targetUrl":"https://login.microsoftonline.com","time":"2023-05-05T16:49:27+02:00","message":"dialing..."}
{"level":"trace","targetUrl":"https://graph.microsoft.com","time":"2023-05-05T16:49:27+02:00","message":"dialing..."}
{"level":"trace","targetUrl":"https://management.azure.com","time":"2023-05-05T16:49:27+02:00","message":"dialing..."}
{"level":"error","error":"map[error:map[code:Authorization_RequestDenied innerError:map[client-request-id:[REDACTED] date:2023-05-05T14:49:27 request-id:[REDACTED]] message:Insufficient privileges to complete the operation.]]","time":"2023-05-05T16:49:27+02:00","message":"unable to get Azure AD organization. It is likely that your user don't have directory reader permissions. If you list non AAD objects (e.g., az-rm) this should be okay."}
{"level":"info","time":"2023-05-05T16:49:27+02:00","message":"collecting azure resource management objects..."}
{"level":"info","time":"2023-05-05T16:49:27+02:00","message":"finished listing all subscription user access admins"}
{"level":"info","time":"2023-05-05T16:49:27+02:00","message":"finished listing all container registries"}
{"level":"info","time":"2023-05-05T16:49:27+02:00","message":"finished listing all virtual machine role assignments"}
{"level":"info","time":"2023-05-05T16:49:27+02:00","message":"finished listing all automation accounts"}
[...]
```