### PR TITLE
Fix to correctly fetch "onPremisesSecurityIdentifier" and onPremisesSyncEnabled" and ""accountEnabled"

### DIFF
--- a/client/users.go
+++ b/client/users.go
@@ -77,6 +77,11 @@ func (s *azureClient) ListAzureADUsers(ctx context.Context, filter string, searc
 			nextLink  string
 		)
 		selectCols := []string{
+			"id",
+			"displayName",
+			"jobTitle",
+			"lastPasswordChangeDateTime",
+			"mail",
 			"onPremisesSecurityIdentifier",
 			"onPremisesSyncEnabled",
 		}

--- a/client/users.go
+++ b/client/users.go
@@ -82,6 +82,7 @@ func (s *azureClient) ListAzureADUsers(ctx context.Context, filter string, searc
 			"jobTitle",
 			"lastPasswordChangeDateTime",
 			"mail",
+			"accountEnabled",
 			"onPremisesSecurityIdentifier",
 			"onPremisesSyncEnabled",
 		}

--- a/client/users.go
+++ b/client/users.go
@@ -76,7 +76,10 @@ func (s *azureClient) ListAzureADUsers(ctx context.Context, filter string, searc
 			errResult = azure.UserResult{}
 			nextLink  string
 		)
-
+		selectCols := []string{
+			"onPremisesSecurityIdentifier",
+			"onPremisesSyncEnabled",
+		}
 		if users, err := s.GetAzureADUsers(ctx, filter, search, orderBy, selectCols, 999, false); err != nil {
 			errResult.Error = err
 			out <- errResult


### PR DESCRIPTION
Added an array containing "onPremisesSecurityIdentifier" and onPremisesSyncEnabled" to fill the $select variable when querying the Graph API at /v1.0/users

As both, Microsoft and the AzureHound, document and state, both datasets are not included in the "default" query and need to be specified as a GET parameter of $select. Please refer to here: 
https://learn.microsoft.com/en-us/graph/api/user-list?view=graph-rest-1.0&tabs=http#optional-query-parameters

And here:
https://github.com/BloodHoundAD/AzureHound/blob/main/models/azure/user.go?plain=1#L323

So this was not fetched, as AzureHound is currently only doing the "default" fetch without $select, resulting in the following data always returned:

![image](https://github.com/BloodHoundAD/AzureHound/assets/58529760/d2efc47d-7486-4267-91a4-13d649fce3ba)


But BloodHound and the ingestor part are already taken both values into consideration. Please see: https://github.com/BloodHoundAD/BloodHound/blob/69786fa46fa18090e7641e086cd2aed70a530748/src/js/ingestion_types.js?plain=1#L523

and:
https://github.com/BloodHoundAD/BloodHound/blob/69786fa46fa18090e7641e086cd2aed70a530748/src/js/newingestion.js?plain=1#L2896

With the changes implemented it now looks "correct":
![image](https://github.com/BloodHoundAD/AzureHound/assets/58529760/7ba98a36-de77-47e3-aafa-f63e5836ed0e)

UPDATE:
I also found out that the enabled info was also not fetched. However, BloodHound in the default configuration "wants" to show this info but was actually never feeded what was needed. Please refer to:
https://github.com/BloodHoundAD/BloodHound/blob/master/src/js/ingestion_types.js?plain=1#L520

and:
https://github.com/BloodHoundAD/BloodHound/blob/master/src/js/newingestion.js?plain=1#L2934

It now shows up like intended:
![image](https://github.com/BloodHoundAD/AzureHound/assets/58529760/19143f18-59ec-41eb-9fbe-aed1fadc694e)
