### PR TITLE
Fix for socket exhaustion

### DIFF
--- a/client/rest/utils.go
+++ b/client/rest/utils.go
@@ -25,7 +25,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"time"
 
@@ -36,7 +35,7 @@ import (
 
 func Decode(body io.ReadCloser, v interface{}) error {
 	defer body.Close()
-	defer ioutil.ReadAll(body)
+	defer io.ReadAll(body) // must read all; streaming to the json decoder does not read to EOF making the connection unavailable for reuse
 	return json.NewDecoder(body).Decode(v)
 }
 

--- a/client/rest/utils.go
+++ b/client/rest/utils.go
@@ -25,6 +25,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"strings"
 	"time"
 

--- a/client/rest/utils.go
+++ b/client/rest/utils.go
@@ -35,6 +35,7 @@ import (
 
 func Decode(body io.ReadCloser, v interface{}) error {
 	defer body.Close()
+	defer ioutil.ReadAll(body)
 	return json.NewDecoder(body).Decode(v)
 }
 


### PR DESCRIPTION
When enumerating a tenant with large amounts of data, connections are not reused and they end up exhausting the system limits, causing a lot of errors such as `i/o timeout`, `connect: connection refused` or `Only one usage of each socket address (protocol/network address/port) is normally permitted.`, which in turn causes that data to be lost during collection.

Based on the documentation for the RestClient and [this](https://stackoverflow.com/questions/17948827/reusing-http-connections-in-go) post, the response body needs to be emptied and then closed for the connection to be returned to the pool for re-use. In my (limited) testing, this resulted in no errors and an increased collection speed.