### PR TITLE
fix: properly synchronize job initiation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.18 as build
+FROM golang:1.20 as build
 WORKDIR /app
 
 ARG VERSION=v0.0.0


### PR DESCRIPTION
Previously the synchronization for starting a job did not work correctly, and two job starts could be queued at once if the first one failed to initialize fast enough