### PR TITLE
Limit information collected by group-members list command

### DIFF
--- a/client/groups.go
+++ b/client/groups.go
@@ -61,10 +61,10 @@ func (s *azureClient) GetAzureADGroupOwners(ctx context.Context, objectId string
 	}
 }
 
-func (s *azureClient) GetAzureADGroupMembers(ctx context.Context, objectId string, filter string, search string, count bool) (azure.MemberObjectList, error) {
+func (s *azureClient) GetAzureADGroupMembers(ctx context.Context, objectId string, filter string, search string, count bool, selectCols []string) (azure.MemberObjectList, error) {
 	var (
 		path     = fmt.Sprintf("/%s/groups/%s/members", constants.GraphApiBetaVersion, objectId)
-		params   = query.Params{Filter: filter, Search: search, Count: count}.AsMap()
+        params   = query.Params{Filter: filter, Search: search, Count: count, Select: selectCols}.AsMap()
 		response azure.MemberObjectList
 	)
 	if res, err := s.msgraph.Get(ctx, path, params, nil); err != nil {
@@ -246,7 +246,7 @@ func (s *azureClient) ListAzureADGroupMembers(ctx context.Context, objectId stri
 			nextLink string
 		)
 
-		if list, err := s.GetAzureADGroupMembers(ctx, objectId, filter, search, false); err != nil {
+		if list, err := s.GetAzureADGroupMembers(ctx, objectId, filter, search, false, selectCols); err != nil {
 			errResult.Error = err
 			if ok := pipeline.Send(ctx.Done(), out, errResult); !ok {
 				return

--- a/cmd/list-group-members.go
+++ b/cmd/list-group-members.go
@@ -92,7 +92,7 @@ func listGroupMembers(ctx context.Context, client client.AzureClient, groups <-c
 					}
 					count = 0
 				)
-				for item := range client.ListAzureADGroupMembers(ctx, id, "", "", "", nil) {
+				for item := range client.ListAzureADGroupMembers(ctx, id, "", "", "", []string{"id"}) {
 					if item.Error != nil {
 						log.Error(item.Error, "unable to continue processing members for this group", "groupId", id)
 					} else {


### PR DESCRIPTION
Dear BloodHound team,

This is possibly breaking change to only collect user IDs when collecting group members. 

Reason for this is that if you run collection of this type in large environment you'd need **VERY** beefy machine to collect it. The I suppose you'd need even beefier machine to import it to neo4j. This happens because plenty of additional information are collected for each member while for most cases collecting group ID and matching user IDs should be enough. It happened to me that I was not even able to collect whole group memberships and the JSON file on disk was already over 200GB.

If this is unacceptable for `list group-members`, how about using this behavior at least for `list az-ad`? The `list az-ad` should collect information about users in each group anyway.