### PR TITLE
fix: load config before initializing logger

### DIFF
--- a/cmd/svc_windows.go
+++ b/cmd/svc_windows.go
@@ -39,13 +39,13 @@ type azurehoundSvc struct {
 }
 
 func (s *azurehoundSvc) Init(env svc.Environment) error {
+	config.LoadValues(nil, config.Options())
+	config.SetAzureDefaults()
+
 	if logr, err := logger.GetLogger(); err != nil {
 		return err
 	} else {
 		log = *logr
-
-		config.LoadValues(nil, config.Options())
-		config.SetAzureDefaults()
 
 		if config.ConfigFileUsed() != "" {
 			log.V(1).Info(fmt.Sprintf("Config File: %v", config.ConfigFileUsed()))

--- a/config/internal/config.go
+++ b/config/internal/config.go
@@ -39,8 +39,10 @@ type Config struct {
 }
 
 func (s Config) Value() interface{} {
-	if reflect.ValueOf(s.Default).Kind() == reflect.Slice {
+	if defkind := reflect.ValueOf(s.Default).Kind(); defkind == reflect.Slice {
 		return viper.GetStringSlice(s.Name)
+	} else if defkind == reflect.Int {
+		return viper.GetInt(s.Name)
 	} else {
 		return viper.Get(s.Name)
 	}

--- a/config/internal/config.go
+++ b/config/internal/config.go
@@ -39,11 +39,12 @@ type Config struct {
 }
 
 func (s Config) Value() interface{} {
-	if defkind := reflect.ValueOf(s.Default).Kind(); defkind == reflect.Slice {
+	switch reflect.ValueOf(s.Default).Kind() {
+	case reflect.Slice:
 		return viper.GetStringSlice(s.Name)
-	} else if defkind == reflect.Int {
+	case reflect.Int:
 		return viper.GetInt(s.Name)
-	} else {
+	default:
 		return viper.Get(s.Name)
 	}
 }

--- a/logger/log_windows.go
+++ b/logger/log_windows.go
@@ -47,11 +47,6 @@ func setupLogger() (*logr.Logger, error) {
 		options.Writers = append(options.Writers, eventLogWriter)
 	}
 
-	// XXX: This is gross, however, reading in the config file when starting the process as a windows service before
-	// initializing the eventLogWriter causes the program to panic. It doesn't make sense as to why it does that but
-	// this call will have to remain here until we can figure out what's going on.
-	config.LoadValues(nil, config.Options())
-
 	// emit logs to file if configured
 	if fileLogWriter := getFileLogLevelWriter(); fileLogWriter != nil {
 		options.Writers = append(options.Writers, fileLogWriter)


### PR DESCRIPTION
This fixes the issue from BED-3824 where AzureHound was not respecting the log verbosity setting while running as a windows service.

Previously the logger was being initialized before the config file was loaded so the logger was being set to the default verbosity value. This was being done for the service because if the config was loaded before initializing the logger, the init code would panic due to verbosity being a float64 but being cast as an int.