### PR TITLE
Support for STDIN for sensitive stuff 

### DIFF
--- a/cmd/list-azure-rm.go
+++ b/cmd/list-azure-rm.go
@@ -78,6 +78,10 @@ func listAllRM(ctx context.Context, client client.AzureClient) <-chan interface{
 		logicApps  = make(chan interface{})
 		logicApps2 = make(chan interface{})
 
+		storageAccounts  = make(chan interface{})
+		storageAccounts2 = make(chan interface{})
+		storageAccounts3 = make(chan interface{})
+
 		managedClusters  = make(chan interface{})
 		managedClusters2 = make(chan interface{})
 
@@ -115,6 +119,7 @@ func listAllRM(ctx context.Context, client client.AzureClient) <-chan interface{
 		subscriptions10              = make(chan interface{})
 		subscriptions11              = make(chan interface{})
 		subscriptions12              = make(chan interface{})
+		subscriptions13              = make(chan interface{})
 		subscriptionRoleAssignments1 = make(chan interface{})
 		subscriptionRoleAssignments2 = make(chan interface{})
 
@@ -142,6 +147,7 @@ func listAllRM(ctx context.Context, client client.AzureClient) <-chan interface{
 		subscriptions10,
 		subscriptions11,
 		subscriptions12,
+		subscriptions13,
 	)
 	pipeline.Tee(ctx.Done(), listResourceGroups(ctx, client, subscriptions2), resourceGroups, resourceGroups2)
 	pipeline.Tee(ctx.Done(), listKeyVaults(ctx, client, subscriptions3), keyVaults, keyVaults2, keyVaults3)
@@ -153,6 +159,7 @@ func listAllRM(ctx context.Context, client client.AzureClient) <-chan interface{
 	pipeline.Tee(ctx.Done(), listLogicApps(ctx, client, subscriptions10), logicApps, logicApps2)
 	pipeline.Tee(ctx.Done(), listManagedClusters(ctx, client, subscriptions11), managedClusters, managedClusters2)
 	pipeline.Tee(ctx.Done(), listVMScaleSets(ctx, client, subscriptions12), vmScaleSets, vmScaleSets2)
+	pipeline.Tee(ctx.Done(), listStorageAccounts(ctx, client, subscriptions13), storageAccounts, storageAccounts2, storageAccounts3)
 
 	// Enumerate Relationships
 	// ManagementGroups: Descendants, Owners and UserAccessAdmins
@@ -196,6 +203,10 @@ func listAllRM(ctx context.Context, client client.AzureClient) <-chan interface{
 	// Enumerate Automation Account Role Assignments
 	automationAccountRoleAssignments := listAutomationAccountRoleAssignments(ctx, client, automationAccounts2)
 
+	//Enumerate storage accounts
+	storageContainers := listStorageContainers(ctx, client, storageAccounts2)
+	storageAccountRoleAssignments := listStorageAccountRoleAssignments(ctx, client, storageAccounts3)
+
 	// Enumerate Container Registry Role Assignments
 	containerRegistryRoleAssignments := listContainerRegistryRoleAssignments(ctx, client, containerRegistries2)
 
@@ -232,6 +243,9 @@ func listAllRM(ctx context.Context, client client.AzureClient) <-chan interface{
 		resourceGroupOwners,
 		resourceGroupUserAccessAdmins,
 		resourceGroups,
+		storageAccounts,
+		storageContainers,
+		storageAccountRoleAssignments,
 		subscriptionOwners,
 		subscriptionUserAccessAdmins,
 		subscriptions,

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -67,6 +67,7 @@ func persistentPreRunE(cmd *cobra.Command, args []string) error {
 
 	config.LoadValues(cmd, config.Options())
 	config.SetAzureDefaults()
+	config.ReadFromStdInput()
 
 	if logr, err := logger.GetLogger(); err != nil {
 		return err

--- a/config/utils.go
+++ b/config/utils.go
@@ -18,12 +18,17 @@
 package config
 
 import (
+	"bufio"
 	"fmt"
 	"net/url"
+	"os"
+	"strings"
+	"syscall"
 
 	client "github.com/bloodhoundad/azurehound/v2/client/config"
 	config "github.com/bloodhoundad/azurehound/v2/config/internal"
 	"github.com/bloodhoundad/azurehound/v2/constants"
+	"golang.org/x/term"
 )
 
 var Init = config.Init
@@ -47,6 +52,67 @@ func SetAzureDefaults() {
 		url := client.ResourceManagerUrl(region, constants.AzureCloud().ResourceManagerUrl)
 		AzMgmtUrl.Set(url)
 	}
+}
+
+func ReadFromStdInput() error {
+	if RefreshToken.Value() == "-" {
+		fmt.Print("Enter Refresh Token: ")
+		rToken, err := term.ReadPassword(int(syscall.Stdin))
+		if err != nil {
+			return err
+		}
+		RefreshToken.Set(strings.TrimSpace(string(rToken)))
+	}
+
+	if JWT.Value() == "-" {
+		fmt.Print("Enter JWT: ")
+		jwt, err := term.ReadPassword(int(syscall.Stdin))
+		if err != nil {
+			return err
+		}
+		JWT.Set((strings.TrimSpace(string(jwt))))
+	}
+
+	if AzSecret.Value() == "-" {
+		fmt.Print("Enter Application Secret: ")
+		azSecret, err := term.ReadPassword(int(syscall.Stdin))
+		if err != nil {
+			return err
+		}
+		AzSecret.Set((strings.TrimSpace(string(azSecret))))
+	}
+
+	if AzKeyPass.Value() == "-" {
+		fmt.Print("Enter Key Passphrase: ")
+		azKeyPass, err := term.ReadPassword(int(syscall.Stdin))
+		if err != nil {
+			return err
+		}
+		AzKeyPass.Set((strings.TrimSpace(string(azKeyPass))))
+	}
+
+	if AzUsername.Value() == "-" {
+		r := bufio.NewReader(os.Stdin)
+		fmt.Print("Enter username: ")
+		azUser, err := r.ReadString('\n')
+		if err != nil {
+			return err
+		}
+		AzUsername.Set(strings.TrimSpace(azUser))
+	}
+
+	if AzPassword.Value() == "-" {
+		fmt.Print("Enter password: ")
+		azPass, err := term.ReadPassword(int(syscall.Stdin))
+		if err != nil {
+			return err
+		}
+		AzPassword.Set((strings.TrimSpace(string(azPass))))
+	}
+
+	//newline to not mess with following logs
+	fmt.Println()
+	return nil
 }
 
 func ValidateURL(input string) error {

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a
 	go.uber.org/mock v0.2.0
 	golang.org/x/net v0.17.0
-	golang.org/x/sys v0.13.0
+	golang.org/x/sys v0.15.0
 )
 
 require (
@@ -34,6 +34,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
 	golang.org/x/crypto v0.14.0 // indirect
+	golang.org/x/term v0.15.0
 	golang.org/x/text v0.13.0 // indirect
 	gopkg.in/ini.v1 v1.66.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -566,7 +566,11 @@ golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
 golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
+golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/term v0.15.0 h1:y/Oo/a/q3IXu26lQgl04j/gjuBDOBlx7X6Om1j2CPW4=
+golang.org/x/term v0.15.0/go.mod h1:BDl952bC7+uMoWR75FIrCDx79TPU9oHkTZ9yRbYOrX0=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/go.sum
+++ b/go.sum
@@ -564,8 +564,6 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
-golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
 golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=


### PR DESCRIPTION
Sensitive information can now be entered in the console on request instead of being provided on the commandline. This can be achieved by supplying a `-` as the value for the parameter.
![image](https://github.com/BloodHoundAD/AzureHound/assets/10261812/4644043f-9bfd-40f4-af5d-9ea9d95d414c)
The following values currently support it:
* Refresh Token - not echoed
* JWT - not echoed
* Application Secret - not echoed
* Key Password - not echoed
* Username
* Password - not echoed

Additionally, re-added storage accounts to the main `list az-rm` command