### PR TITLE
BED-4273  azurehound backoff retry

### DIFF
--- a/client/rest/client.go
+++ b/client/rest/client.go
@@ -218,23 +218,9 @@ func (s *restClient) Send(req *http.Request) (*http.Response, error) {
 	return s.send(req)
 }
 
-func copyBody(req *http.Request) ([]byte, error) {
-	var (
-		body []byte
-		err  error
-	)
-	if req.Body != nil {
-		body, err = io.ReadAll(req.Body)
-		if body != nil {
-			req.Body = io.NopCloser(bytes.NewBuffer(body))
-		}
-	}
-	return body, err
-}
-
 func (s *restClient) send(req *http.Request) (*http.Response, error) {
 	// copy the bytes in case we need to retry the request
-	if body, err := copyBody(req); err != nil {
+	if body, err := CopyBody(req); err != nil {
 		return nil, err
 	} else {
 		var (

--- a/client/rest/client.go
+++ b/client/rest/client.go
@@ -240,7 +240,7 @@ func (s *restClient) send(req *http.Request) (*http.Response, error) {
 			// Try the request
 			if res, err = s.http.Do(req); err != nil {
 				if IsClosedConnectionErr(err) {
-					fmt.Printf("remote host force closed connection while requesting %s; attempt %d/%d; trying again\n", req.URL, retry+1, maxRetries)
+					fmt.Printf("remote host force closed connection while requesting %s; attempt %d/%d; trying again...\n", req.URL, retry+1, maxRetries)
 					ExponentialBackoff(retry)
 					continue
 				}

--- a/client/rest/client.go
+++ b/client/rest/client.go
@@ -25,7 +25,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -274,8 +273,7 @@ func (s *restClient) send(req *http.Request) (*http.Response, error) {
 					}
 				} else if res.StatusCode >= http.StatusInternalServerError {
 					// Wait the time calculated by the 5 second exponential backoff
-					backoff := math.Pow(5, float64(retry+1))
-					time.Sleep(time.Second * time.Duration(backoff))
+					ExponentialBackoff(retry, maxRetries)
 					continue
 				} else {
 					// Not a status code that warrants a retry

--- a/client/rest/client.go
+++ b/client/rest/client.go
@@ -257,8 +257,8 @@ func (s *restClient) send(req *http.Request) (*http.Response, error) {
 			if res, err = s.http.Do(req); err != nil {
 				// TODO: maybe add a test case for this?
 				if strings.Contains(err.Error(), "An existing connection was forcibly closed by the remote host.") {
-					// TODO: probably should use a proper logger here?
-					fmt.Printf("ERR attempt=%d | req=%s | error=%v", retry+1, req.URL, err)
+
+					fmt.Printf("remote host force closed connection while requesting %s; attempt %d/%d; trying again", req.URL, retry+1, maxRetries)
 					backoff := math.Pow(5, float64(retry+1))
 					time.Sleep(time.Second * time.Duration(backoff))
 					continue

--- a/client/rest/client.go
+++ b/client/rest/client.go
@@ -241,7 +241,7 @@ func (s *restClient) send(req *http.Request) (*http.Response, error) {
 			if res, err = s.http.Do(req); err != nil {
 				if IsClosedConnectionErr(err) {
 					fmt.Printf("remote host force closed connection while requesting %s; attempt %d/%d; trying again\n", req.URL, retry+1, maxRetries)
-					ExponentialBackoff(retry, maxRetries)
+					ExponentialBackoff(retry)
 					continue
 				}
 				return nil, err
@@ -259,7 +259,7 @@ func (s *restClient) send(req *http.Request) (*http.Response, error) {
 					}
 				} else if res.StatusCode >= http.StatusInternalServerError {
 					// Wait the time calculated by the 5 second exponential backoff
-					ExponentialBackoff(retry, maxRetries)
+					ExponentialBackoff(retry)
 					continue
 				} else {
 					// Not a status code that warrants a retry

--- a/client/rest/client.go
+++ b/client/rest/client.go
@@ -255,10 +255,9 @@ func (s *restClient) send(req *http.Request) (*http.Response, error) {
 
 			// Try the request
 			if res, err = s.http.Do(req); err != nil {
-				// TODO: maybe add a test case for this?
-				if strings.Contains(err.Error(), "An existing connection was forcibly closed by the remote host.") {
-
-					fmt.Printf("remote host force closed connection while requesting %s; attempt %d/%d; trying again", req.URL, retry+1, maxRetries)
+				closedConnectionMsg := "An existing connection was forcibly closed by the remote host."
+				if strings.Contains(err.Error(), closedConnectionMsg) || strings.HasSuffix(err.Error(), ": EOF") {
+					fmt.Printf("remote host force closed connection while requesting %s; attempt %d/%d; trying again\n", req.URL, retry+1, maxRetries)
 					backoff := math.Pow(5, float64(retry+1))
 					time.Sleep(time.Second * time.Duration(backoff))
 					continue

--- a/client/rest/client.go
+++ b/client/rest/client.go
@@ -240,7 +240,7 @@ func (s *restClient) send(req *http.Request) (*http.Response, error) {
 			// Try the request
 			if res, err = s.http.Do(req); err != nil {
 				if IsClosedConnectionErr(err) {
-					fmt.Printf("remote host force closed connection while requesting %s; attempt %d/%d; trying again...\n", req.URL, retry+1, maxRetries)
+					fmt.Printf("remote host force closed connection while requesting %s; attempt %d/%d; trying again\n", req.URL, retry+1, maxRetries)
 					ExponentialBackoff(retry)
 					continue
 				}

--- a/client/rest/client.go
+++ b/client/rest/client.go
@@ -254,8 +254,10 @@ func (s *restClient) send(req *http.Request) (*http.Response, error) {
 
 			// Try the request
 			if res, err = s.http.Do(req); err != nil {
-				// client error
-				return nil, err
+				fmt.Printf("ERR attempt=%d | req=%s | error=%v", retry+1, req.URL, err)
+				backoff := math.Pow(5, float64(retry+1))
+				time.Sleep(time.Second * time.Duration(backoff))
+				continue
 			} else if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusBadRequest {
 				// Error response code handling
 				// See official Retry guidance (https://learn.microsoft.com/en-us/azure/architecture/best-practices/retry-service-specific#retry-usage-guidance)

--- a/client/rest/client_test.go
+++ b/client/rest/client_test.go
@@ -50,8 +50,8 @@ func TestClosedConnection(t *testing.T) {
 
 		// make request in separate goroutine so its not blocking after we validated the retry
 		go func() {
-			client.Authenticate() // Authenticate()because it uses the internal client.send method.
-			// the above request should block this from running, however if it does then the test fails.
+			client.Authenticate() // Authenticate() because it uses the internal client.send method.
+			// the above request should block the request from completing, however if it does then the test fails.
 			requestCompleted = true
 		}()
 

--- a/client/rest/client_test.go
+++ b/client/rest/client_test.go
@@ -1,0 +1,39 @@
+// Copyright (C) 2024 Specter Ops, Inc.
+//
+// This file is part of AzureHound.
+//
+// AzureHound is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// AzureHound is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package rest
+
+import (
+	"testing"
+)
+
+func TestClosedConnection(t *testing.T) {
+	// var s *httptest.Server
+	// var h http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
+	// 	fmt.Println("closing client connections")
+	// 	s.CloseClientConnections()
+	// }
+	// s = httptest.NewServer(h)
+	// defer s.Close()
+
+	// res, err := RestClient.Get(gomock.Any(), s.URL)
+	// if err == nil {
+	// 	t.Fatalf("Something aint right, err should be nil %v", err)
+	// }
+
+	// fmt.Printf("res:%v,err:%v", res, err)
+}

--- a/client/rest/client_test.go
+++ b/client/rest/client_test.go
@@ -51,7 +51,7 @@ func TestClosedConnection(t *testing.T) {
 		// make request in separate goroutine so its not blocking after we validated the retry
 		go func() {
 			client.Authenticate() // Authenticate() because it uses the internal client.send method.
-			// the above request should block the request from completing, however if it does then the test fails.
+			// CloseClientConnections should block the request from completing, however if it completes then the test fails.
 			requestCompleted = true
 		}()
 

--- a/client/rest/utils.go
+++ b/client/rest/utils.go
@@ -133,7 +133,7 @@ func IsClosedConnectionErr(err error) bool {
 	return closedFromClient || closedFromTestCase
 }
 
-func ExponentialBackoff(retry int, maxRetries int) {
+func ExponentialBackoff(retry int) {
 	backoff := math.Pow(5, float64(retry+1))
 	time.Sleep(time.Second * time.Duration(backoff))
 }

--- a/client/rest/utils.go
+++ b/client/rest/utils.go
@@ -127,8 +127,7 @@ func x5t(certificate string) (string, error) {
 func IsClosedConnectionErr(err error) bool {
 	var closedConnectionMsg = "An existing connection was forcibly closed by the remote host."
 	closedFromClient := strings.Contains(err.Error(), closedConnectionMsg)
-	// Mocking http.Do would require a larger refactor,
-	// so closedFromTestCase is used for testing only.
+	// Mocking http.Do would require a larger refactor, so closedFromTestCase is used to cover testing only.
 	closedFromTestCase := strings.HasSuffix(err.Error(), ": EOF")
 	return closedFromClient || closedFromTestCase
 }

--- a/client/rest/utils.go
+++ b/client/rest/utils.go
@@ -126,6 +126,8 @@ var ClosedConnectionMsg = "An existing connection was forcibly closed by the rem
 
 func IsClosedConnectionErr(err error) bool {
 	closedFromClient := strings.Contains(err.Error(), ClosedConnectionMsg)
+	// Mocking http.Do would require a larger refactor,
+	// so closedFromTestCase is used for testing only.
 	closedFromTestCase := strings.HasSuffix(err.Error(), ": EOF")
 	return closedFromClient || closedFromTestCase
 }

--- a/client/rest/utils.go
+++ b/client/rest/utils.go
@@ -25,6 +25,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
+	"math"
 	"strings"
 	"time"
 
@@ -119,4 +120,17 @@ func x5t(certificate string) (string, error) {
 		checksum := sha1.Sum(cert.Raw)
 		return base64.StdEncoding.EncodeToString(checksum[:]), nil
 	}
+}
+
+var ClosedConnectionMsg = "An existing connection was forcibly closed by the remote host."
+
+func IsClosedConnectionErr(err error) bool {
+	closedFromClient := strings.Contains(err.Error(), ClosedConnectionMsg)
+	closedFromTestCase := strings.HasSuffix(err.Error(), ": EOF")
+	return closedFromClient || closedFromTestCase
+}
+
+func ExponentialBackoff(retry int, maxRetries int) {
+	backoff := math.Pow(5, float64(retry+1))
+	time.Sleep(time.Second * time.Duration(backoff))
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -220,7 +220,7 @@ func ingest(ctx context.Context, bheUrl url.URL, bheClient *http.Client, in <-ch
 				if response, err := bheClient.Do(req); err != nil {
 					if rest.IsClosedConnectionErr(err) {
 						// try again on force closed connection
-						log.Error(err, "remote host force closed connection while requesting %s; attempt %d/%d; trying again...\n", req.URL, retry+1, maxRetries)
+						log.Error(err, "remote host force closed connection while requesting %s; attempt %d/%d; trying again...", req.URL, retry+1, maxRetries)
 						rest.ExponentialBackoff(retry)
 
 						if retry == maxRetries-1 {
@@ -288,7 +288,7 @@ func do(bheClient *http.Client, req *http.Request) (*http.Response, error) {
 			if res, err = bheClient.Do(req); err != nil {
 				if rest.IsClosedConnectionErr(err) {
 					// try again on force closed connections
-					log.Error(err, "remote host force closed connection while requesting %s; attempt %d/%d; trying again...\n", req.URL, retry+1, maxRetries)
+					log.Error(err, "remote host force closed connection while requesting %s; attempt %d/%d; trying again...", req.URL, retry+1, maxRetries)
 					rest.ExponentialBackoff(retry)
 					continue
 				}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -288,7 +288,7 @@ func do(bheClient *http.Client, req *http.Request) (*http.Response, error) {
 		if res, err = bheClient.Do(req); err != nil {
 			if strings.Contains(err.Error(), "An existing connection was forcibly closed by the remote host.") {
 				// try again on force closed connections
-				log.Error(err, "server error while requesting %s; attempt %d/%d; trying again", req.URL, retry+1, maxRetries)
+				log.Error(err, "remote host force closed connection while requesting %s; attempt %d/%d; trying again", req.URL, retry+1, maxRetries)
 				backoff := math.Pow(5, float64(retry+1))
 				time.Sleep(time.Second * time.Duration(backoff))
 				continue

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -220,7 +220,7 @@ func ingest(ctx context.Context, bheUrl url.URL, bheClient *http.Client, in <-ch
 				if response, err := bheClient.Do(req); err != nil {
 					if rest.IsClosedConnectionErr(err) {
 						// try again on force closed connection
-						log.Error(err, "remote host force closed connection while requesting %s; attempt %d/%d; trying again...", req.URL, retry+1, maxRetries)
+						log.Error(err, "remote host force closed connection while requesting %s; attempt %d/%d; trying again", req.URL, retry+1, maxRetries)
 						rest.ExponentialBackoff(retry)
 
 						if retry == maxRetries-1 {
@@ -233,8 +233,8 @@ func ingest(ctx context.Context, bheUrl url.URL, bheClient *http.Client, in <-ch
 					log.Error(err, unrecoverableErrMsg)
 					return true
 				} else if response.StatusCode == http.StatusGatewayTimeout || response.StatusCode == http.StatusServiceUnavailable || response.StatusCode == http.StatusBadGateway {
-					serverError := fmt.Errorf("received server error %d while requesting %v;", response.StatusCode, endpoint)
-					log.Error(serverError, "attempt %d/%d; trying again...", retry+1, maxRetries)
+					serverError := fmt.Errorf("received server error %d while requesting %v; attempt %d/%d; trying again", response.StatusCode, endpoint, retry+1, maxRetries)
+					log.Error(serverError, "")
 
 					rest.ExponentialBackoff(retry)
 
@@ -288,7 +288,7 @@ func do(bheClient *http.Client, req *http.Request) (*http.Response, error) {
 			if res, err = bheClient.Do(req); err != nil {
 				if rest.IsClosedConnectionErr(err) {
 					// try again on force closed connections
-					log.Error(err, "remote host force closed connection while requesting %s; attempt %d/%d; trying again...", req.URL, retry+1, maxRetries)
+					log.Error(err, "remote host force closed connection while requesting %s; attempt %d/%d; trying again", req.URL, retry+1, maxRetries)
 					rest.ExponentialBackoff(retry)
 					continue
 				}
@@ -298,7 +298,7 @@ func do(bheClient *http.Client, req *http.Request) (*http.Response, error) {
 				if res.StatusCode >= http.StatusInternalServerError {
 					// Internal server error, backoff and try again.
 					serverError := fmt.Errorf("received server error %d while requesting %v", res.StatusCode, req.URL)
-					log.Error(serverError, "attempt %d/%d; trying again...", retry+1, maxRetries)
+					log.Error(serverError, "attempt %d/%d; trying again", retry+1, maxRetries)
 
 					rest.ExponentialBackoff(retry)
 					continue

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -221,7 +221,7 @@ func ingest(ctx context.Context, bheUrl url.URL, bheClient *http.Client, in <-ch
 				if response, err := bheClient.Do(req); err != nil {
 					if rest.IsClosedConnectionErr(err) {
 						// try again on force closed connection
-						log.Error(err, "remote host force closed connection while requesting %s; attempt %d/%d; trying again\n", req.URL, retry+1, maxRetries)
+						log.Error(err, "remote host force closed connection while requesting %s; attempt %d/%d; trying again...\n", req.URL, retry+1, maxRetries)
 						rest.ExponentialBackoff(retry)
 						continue
 					}
@@ -283,7 +283,7 @@ func do(bheClient *http.Client, req *http.Request) (*http.Response, error) {
 			if res, err = bheClient.Do(req); err != nil {
 				if rest.IsClosedConnectionErr(err) {
 					// try again on force closed connections
-					log.Error(err, "remote host force closed connection while requesting %s; attempt %d/%d; trying again\n", req.URL, retry+1, maxRetries)
+					log.Error(err, "remote host force closed connection while requesting %s; attempt %d/%d; trying again...\n", req.URL, retry+1, maxRetries)
 					rest.ExponentialBackoff(retry)
 					continue
 				}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -220,7 +220,7 @@ func ingest(ctx context.Context, bheUrl url.URL, bheClient *http.Client, in <-ch
 				if response, err := bheClient.Do(req); err != nil {
 					if rest.IsClosedConnectionErr(err) {
 						// try again on force closed connection
-						log.Error(err, "remote host force closed connection while requesting %s; attempt %d/%d; trying again", req.URL, retry+1, maxRetries)
+						log.Error(err, fmt.Sprintf("remote host force closed connection while requesting %s; attempt %d/%d; trying again", req.URL, retry+1, maxRetries))
 						rest.ExponentialBackoff(retry)
 
 						if retry == maxRetries-1 {
@@ -288,7 +288,7 @@ func do(bheClient *http.Client, req *http.Request) (*http.Response, error) {
 			if res, err = bheClient.Do(req); err != nil {
 				if rest.IsClosedConnectionErr(err) {
 					// try again on force closed connections
-					log.Error(err, "remote host force closed connection while requesting %s; attempt %d/%d; trying again", req.URL, retry+1, maxRetries)
+					log.Error(err, fmt.Sprintf("remote host force closed connection while requesting %s; attempt %d/%d; trying again", req.URL, retry+1, maxRetries))
 					rest.ExponentialBackoff(retry)
 					continue
 				}
@@ -298,7 +298,7 @@ func do(bheClient *http.Client, req *http.Request) (*http.Response, error) {
 				if res.StatusCode >= http.StatusInternalServerError {
 					// Internal server error, backoff and try again.
 					serverError := fmt.Errorf("received server error %d while requesting %v", res.StatusCode, req.URL)
-					log.Error(serverError, "attempt %d/%d; trying again", retry+1, maxRetries)
+					log.Error(serverError, fmt.Sprintf("attempt %d/%d; trying again", retry+1, maxRetries))
 
 					rest.ExponentialBackoff(retry)
 					continue

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -214,7 +214,6 @@ func ingest(ctx context.Context, bheUrl url.URL, bheClient *http.Client, in <-ch
 		} else {
 			req.Header.Set("User-Agent", constants.UserAgent())
 			req.Header.Set("Accept", "application/json")
-			req.Header.Set("Prefer", "wait=60")
 			req.Header.Set("Content-Encoding", "gzip")
 			for retry := 0; retry < maxRetries; retry++ {
 				// No retries on regular err cases, only on HTTP 504 Gateway Timeout and HTTP 503 Service Unavailable

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -222,16 +222,16 @@ func ingest(ctx context.Context, bheUrl url.URL, bheClient *http.Client, in <-ch
 					if rest.IsClosedConnectionErr(err) {
 						// try again on force closed connection
 						log.Error(err, "remote host force closed connection while requesting %s; attempt %d/%d; trying again\n", req.URL, retry+1, maxRetries)
-						rest.ExponentialBackoff(retry, maxRetries)
+						rest.ExponentialBackoff(retry)
 						continue
 					}
 					log.Error(err, unrecoverableErrMsg)
 					return true
 				} else if response.StatusCode == http.StatusGatewayTimeout || response.StatusCode == http.StatusServiceUnavailable || response.StatusCode == http.StatusBadGateway {
 					serverError := fmt.Errorf("received server error %d while requesting %v;", response.StatusCode, endpoint)
-					log.Error(serverError, "attempt %d/%d; trying again", retry+1, maxRetries)
+					log.Error(serverError, "attempt %d/%d; trying again...", retry+1, maxRetries)
 
-					rest.ExponentialBackoff(retry, maxRetries)
+					rest.ExponentialBackoff(retry)
 
 					if retry == maxRetries-1 {
 						log.Error(ErrExceededRetryLimit, "")
@@ -284,7 +284,7 @@ func do(bheClient *http.Client, req *http.Request) (*http.Response, error) {
 				if rest.IsClosedConnectionErr(err) {
 					// try again on force closed connections
 					log.Error(err, "remote host force closed connection while requesting %s; attempt %d/%d; trying again\n", req.URL, retry+1, maxRetries)
-					rest.ExponentialBackoff(retry, maxRetries)
+					rest.ExponentialBackoff(retry)
 					continue
 				}
 				// normal client error, dont attempt again
@@ -293,9 +293,9 @@ func do(bheClient *http.Client, req *http.Request) (*http.Response, error) {
 				if res.StatusCode >= http.StatusInternalServerError {
 					// Internal server error, backoff and try again.
 					serverError := fmt.Errorf("received server error %d while requesting %v", res.StatusCode, req.URL)
-					log.Error(serverError, "attempt %d/%d", retry+1, maxRetries)
+					log.Error(serverError, "attempt %d/%d; trying again...", retry+1, maxRetries)
 
-					rest.ExponentialBackoff(retry, maxRetries)
+					rest.ExponentialBackoff(retry)
 					continue
 				}
 				// bad request we do not need to retry

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -233,8 +232,7 @@ func ingest(ctx context.Context, bheUrl url.URL, bheClient *http.Client, in <-ch
 					serverError := fmt.Errorf("received server error %d while requesting %v", response.StatusCode, endpoint)
 					log.Error(serverError, "attempt %d/%d", retry+1, maxRetries)
 
-					backoff := math.Pow(5, float64(retry+1))
-					time.Sleep(time.Second * time.Duration(backoff))
+					rest.ExponentialBackoff(retry, maxRetries)
 
 					if retry == maxRetries-1 {
 						log.Error(ErrExceededRetryLimit, "")
@@ -306,8 +304,7 @@ func do(bheClient *http.Client, req *http.Request) (*http.Response, error) {
 				serverError := fmt.Errorf("received server error %d while requesting %v", res.StatusCode, req.URL)
 				log.Error(serverError, "attempt %d/%d", retry+1, maxRetries)
 
-				backoff := math.Pow(5, float64(retry+1))
-				time.Sleep(time.Second * time.Duration(backoff))
+				rest.ExponentialBackoff(retry, maxRetries)
 				continue
 			}
 			// bad request we do not need to retry

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -222,6 +222,12 @@ func ingest(ctx context.Context, bheUrl url.URL, bheClient *http.Client, in <-ch
 						// try again on force closed connection
 						log.Error(err, "remote host force closed connection while requesting %s; attempt %d/%d; trying again...\n", req.URL, retry+1, maxRetries)
 						rest.ExponentialBackoff(retry)
+
+						if retry == maxRetries-1 {
+							log.Error(ErrExceededRetryLimit, "")
+							hasErrors = true
+						}
+
 						continue
 					}
 					log.Error(err, unrecoverableErrMsg)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -266,7 +266,6 @@ func ingest(ctx context.Context, bheUrl url.URL, bheClient *http.Client, in <-ch
 func do(bheClient *http.Client, req *http.Request) (*http.Response, error) {
 	var (
 		res        *http.Response
-		err        error
 		maxRetries = 3
 	)
 
@@ -313,7 +312,7 @@ func do(bheClient *http.Client, req *http.Request) (*http.Response, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("unable to complete request to url=%s; attempts=%d; ERR=%w", req.URL, maxRetries, err)
+	return nil, fmt.Errorf("unable to complete request to url=%s; attempts=%d;", req.URL, maxRetries)
 }
 
 type basicResponse[T any] struct {


### PR DESCRIPTION
BED-4273

Adds backoff/retry logic to force closed connection and 502 bad gateway responses. Removes timeout on ingest requests

## Implementation
added checks when making requests to azure and bhe api.

## Testing
Added `TestClosedConnection` to test the retry logic from a force-closed connection.