### PR TITLE
fix: app scoped role assignment not properly linking to AZApp

### DIFF
--- a/models/azure/unified_role_assignment.go
+++ b/models/azure/unified_role_assignment.go
@@ -67,7 +67,7 @@ type UnifiedRoleAssignment struct {
 	// The directory object that is the scope of the assignment.
 	// Read-only.
 	// Supports $expand.
-	DirectoryScope json.RawMessage
+	DirectoryScope Application `json:"directoryScope,omitempty"`
 
 	// Read-only property with details of the app specific scope when the assignment scope is app specific.
 	// Containment entity.


### PR DESCRIPTION
BED-4348

Adds workaround handling for app specific scoped role assignments. This ensures that downstream ingestion by Bloodhound will add edge to correct `AZApp` node

## Implementation
Expanded `directoryScope` in `ListAzureADRoleAssignments` which provides the `appId` of the scoped app.
Hotswapped that in place for the `directoryScopeId` to be consumed downstream.

No changes needed to Bloodhound.

## Testing
Ran collection locally pointing at Azure env with role assignment scoped to specific app and ensured that it was properly linked in Bloodhound.

Query: ```MATCH p = (:AZUser)-[:AZAppAdmin]->()```