### PR TITLE
chore:  make empty data cleanup more aggressive

### DIFF
--- a/models/utils.go
+++ b/models/utils.go
@@ -22,11 +22,23 @@ func StripEmptyEntries(data map[string]any) {
 		} else if nested, ok := value.(map[string]any); ok { // recursively strip nested maps
 			StripEmptyEntries(nested)
 		} else if slice, ok := value.([]any); ok {
+			value = make([]any, len(value.([]any)))
+			i := 0
 			for _, item := range slice {
 				if mapValue, ok := item.(map[string]any); ok {
 					StripEmptyEntries(mapValue)
 				}
+				if !isEmpty(reflect.ValueOf(item)) {
+					value.([]any)[i] = item
+					i++
+				}
 			}
+			value = value.([]any)[:i]
+		}
+
+		// Strip top level if empty post recursive strip
+		if _, ok := data[key]; ok && isEmpty(reflect.ValueOf(value)) {
+			delete(data, key)
 		}
 	}
 }


### PR DESCRIPTION
## Description

Part 1 of BED-4586

We currently do not strip empty top level structs or slices, this is a small change to make the stripping utility more aggressive.


## Motivation and Context
Decrease file size by removing empty properties

## How Has This Been Tested?

Ran locally
Updated unit tests

## Types of changes

- Chore (a change that does not modify the application functionality)
- Could be considered breaking in the empty fields will no longer be present that were previously present

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
