### PR TITLE
BED-4800: Update default values and max streams for performance

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -303,9 +303,9 @@ var (
 		Usage:      "The number of threads to use when collecting various resources.",
 		Persistent: true,
 		Required:   false,
-		Default:    2,
+		Default:    25,
 		MinValue:   1,
-		MaxValue:   25,
+		MaxValue:   50,
 	}
 
 	// Command specific configurations


### PR DESCRIPTION
v2.2.0 showed significant performance degradation with the updated defaults. We're dropping the number of concurrent connections to reduce the number of back-off requests from Azure APIs, increasing collection speed overall for large environments while maintaining the same stream concurrency. 