### PR TITLE
BED-4776: Add .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# An approval from a member of the BloodHound Engineering team will be
+# required when someone opens a pull request.
+* @BloodHoundAD/engineering


### PR DESCRIPTION
This PR addresses: BED-4776

Adds a new CODEOWNERS file to declare members of @BloodHoundAD/engineering as the code owners for the entire repository.

This change will enable us to require at least 1 approval from a member of the BloodHound Engineering team for all future pull requests.

To learn more about code owners please read the docs kindly provided by GitHub.
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners