### PR TITLE
Revert "BED-4776: Add .github/CODEOWNERS"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,0 @@
-# An approval from a member of the BloodHound Engineering team will be
-# required when someone opens a pull request.
-* @BloodHoundAD/engineering


### PR DESCRIPTION
Reverts BloodHoundAD/AzureHound#86

Reverting this since it is creating unwanted noise in emails by subscribing the entire team to every PR opened.