### PR TITLE
update logic and web app

### DIFF
--- a/cmd/list-function-apps.go
+++ b/cmd/list-function-apps.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"time"
 
@@ -102,14 +103,19 @@ func listFunctionApps(ctx context.Context, client client.AzureClient, subscripti
 							ResourceGroupName: item.Ok.ResourceGroupName(),
 							TenantId:          client.TenantInfo().TenantId,
 						}
-						if functionApp.Kind == "functionapp" {
-							log.V(2).Info("found function app", "functionApp", functionApp)
-							count++
-							if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
-								Kind: enums.KindAZFunctionApp,
-								Data: functionApp,
-							}); !ok {
-								return
+						kinds := strings.Split(functionApp.Kind, ",")
+						for _, kind := range kinds {
+							kind = strings.TrimSpace(kind)
+							if strings.EqualFold(kind, "functionapp") {
+								log.V(2).Info("found function app", "functionApp", functionApp)
+								count++
+								if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
+									Kind: enums.KindAZFunctionApp,
+									Data: functionApp,
+								}); !ok {
+									return
+								}
+								break
 							}
 						}
 					}

--- a/cmd/list-web-apps.go
+++ b/cmd/list-web-apps.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"time"
 
@@ -107,14 +108,19 @@ func listWebApps(ctx context.Context, client client.AzureClient, subscriptions <
 							ResourceGroupName: item.Ok.ResourceGroupName(),
 							TenantId:          client.TenantInfo().TenantId,
 						}
-						if webApp.Kind == "app" {
-							log.V(2).Info("found web app", "webApp", webApp)
-							count++
-							if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
-								Kind: enums.KindAZWebApp,
-								Data: webApp,
-							}); !ok {
-								return
+						kinds := strings.Split(webApp.Kind, ",")
+						for _, kind := range kinds {
+							kind = strings.TrimSpace(kind)
+							if strings.EqualFold(kind, "app") {
+								log.V(2).Info("found web app", "webApp", webApp)
+								count++
+								if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
+									Kind: enums.KindAZWebApp,
+									Data: webApp,
+								}); !ok {
+									return
+								}
+								break
 							}
 						}
 					}


### PR DESCRIPTION
Changes:

list-function-apps.go
list-web-apps.go

`AZFunctionApp` and `AZWebapp` do not correctly display neo4j entities due to the keyword checks failing; specifically `functionapp` and `app`. The kind attribute may contain more than one value separated by a comma.

Observed variations from AppServices:

```
functionapp,workflowapp
<class 'str'>

app,linux
<class 'str'>

functionapp,linux
<class 'str'>
```