### PR TITLE
Add example on how to reuse existing Azure CLI authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ go build -ldflags="-s -w -X github.com/bloodhoundad/azurehound/v2/constants.Vers
 ❯ azurehound list -u "$USERNAME" -p "$PASSWORD" -t "$TENANT" -o "mytenant.json"
 ```
 
+**Print all Azure Tenant data to file, reusing your existing authentication from the Azure CLI**
+
+```
+❯ JWT=$(az account get-access-token --resource https://graph.microsoft.com | jq -r .accessToken)
+❯ azurehound list --jwt "$JWT"
+```
+
 **Configure and start data collection service for BloodHound Enterprise**
 
 ```sh


### PR DESCRIPTION
Although some people (e.g. https://github.com/SpecterOps/AzureHound/issues/75) seem to think creating an app registration is required, it's actually very easy to reuse your current authentication from the Azure CLI, even if the tenant you're in requires MFA

This makes it much easier on `az` users, while avoiding to create unnecessary app registrations