### PR TITLE
fix functionApp matching to allow for other possible Kind values

### DIFF
--- a/cmd/list-function-apps.go
+++ b/cmd/list-function-apps.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"time"
 
@@ -102,7 +103,7 @@ func listFunctionApps(ctx context.Context, client client.AzureClient, subscripti
 							ResourceGroupName: item.Ok.ResourceGroupName(),
 							TenantId:          client.TenantInfo().TenantId,
 						}
-						if functionApp.Kind == "functionapp" {
+						if strings.Contains(functionApp.Kind, "functionapp") {
 							log.V(2).Info("found function app", "functionApp", functionApp)
 							count++
 							if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{


### PR DESCRIPTION
Fixes an issue ([#72](https://github.com/SpecterOps/AzureHound/issues/72)) where list-function-apps fails to properly detect Function Apps when the Azure Management API returns a "kind" value like
 `functionapp,linux` 

The current code checks for an exact match (functionApp.Kind == "functionapp"), which doesn't account for cases where additional qualifiers (like `,linux`) are included. Examples here: [https://github.com/Azure/app-service-linux-docs/blob/master/Things_You_Should_Know/kind_property.md](https://github.com/Azure/app-service-linux-docs/blob/master/Things_You_Should_Know/kind_property.md)