### PR TITLE
Checksum EXEs, flatten signed zip artifacts to better match unsigned artifact composition

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,11 @@ jobs:
           name: azurehound-bin-${{ matrix.os }}-${{ matrix.arch }}
           path: azurehound*
 
+      - name: Create Executable Checksums
+        run: |
+          file=$(ls azurehound*)
+          sha256sum $file > ${file}.sha256
+
       - name: Zip
         run: 7z a -tzip -mx9 ${{ env.FILE_NAME }}.zip azurehound*
 
@@ -134,6 +139,12 @@ jobs:
           for artifact in signed/*; do
             osslsigncode verify -CAfile cert-chain.pem "$artifact"
           done
+
+      - name: Create Executable Checksums
+        run: |
+          cd signed
+          file=$(ls azurehound*)
+          sha256sum $file > ${file}.sha256
 
       - name: Zip Signed Executables
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -138,7 +138,8 @@ jobs:
       - name: Zip Signed Executables
         run: |
           mkdir zipped
-          7z a -tzip -mx9 zipped/${{ env.FILE_NAME }}.zip signed/*
+          cd signed
+          7z a -tzip -mx9 ../zipped/${{ env.FILE_NAME }}.zip *
 
       - name: Checksum Zipped Files
         run: |


### PR DESCRIPTION
Removing the nested "signed" directories, moving the .exe up one level.
Additionally compute and wrap executable binary checksums into .zip archives.

<img width="328" alt="image" src="https://github.com/user-attachments/assets/432ca65f-e065-4cb8-be74-c3a40af3faf5" />