### PR TITLE
BED-4884: Fix incorrect tenant ID on subscriptions management groups

### DIFF
--- a/cmd/list-management-groups.go
+++ b/cmd/list-management-groups.go
@@ -75,8 +75,7 @@ func listManagementGroups(ctx context.Context, client client.AzureClient) <-chan
 				count++
 				mgmtGroup := models.ManagementGroup{
 					ManagementGroup: item.Ok,
-					TenantId:        client.TenantInfo().TenantId,
-					TenantName:      client.TenantInfo().DisplayName,
+					TenantId:        item.Ok.Properties.TenantId,
 				}
 
 				if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{

--- a/cmd/list-management-groups_test.go
+++ b/cmd/list-management-groups_test.go
@@ -39,9 +39,7 @@ func TestListManagementGroups(t *testing.T) {
 
 	mockClient := mocks.NewMockAzureClient(ctrl)
 	mockChannel := make(chan client.AzureResult[azure.ManagementGroup])
-	mockTenant := azure.Tenant{}
 	mockError := fmt.Errorf("I'm an error")
-	mockClient.EXPECT().TenantInfo().Return(mockTenant).AnyTimes()
 	mockClient.EXPECT().ListAzureManagementGroups(gomock.Any(), gomock.Any()).Return(mockChannel)
 
 	go func() {

--- a/cmd/list-subscriptions.go
+++ b/cmd/list-subscriptions.go
@@ -99,7 +99,7 @@ func listSubscriptions(ctx context.Context, client client.AzureClient) <-chan in
 				data := models.Subscription{
 					Subscription: item.Ok,
 				}
-				data.TenantId = client.TenantInfo().TenantId
+				data.TenantId = item.Ok.TenantId
 				if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
 					Kind: enums.KindAZSubscription,
 					Data: data,

--- a/cmd/list-subscriptions_test.go
+++ b/cmd/list-subscriptions_test.go
@@ -39,9 +39,7 @@ func TestListSubscriptions(t *testing.T) {
 
 	mockClient := mocks.NewMockAzureClient(ctrl)
 	mockChannel := make(chan client.AzureResult[azure.Subscription])
-	mockTenant := azure.Tenant{}
 	mockError := fmt.Errorf("I'm an error")
-	mockClient.EXPECT().TenantInfo().Return(mockTenant).AnyTimes()
 	mockClient.EXPECT().ListAzureSubscriptions(gomock.Any()).Return(mockChannel)
 
 	go func() {

--- a/models/mgmt-group.go
+++ b/models/mgmt-group.go
@@ -23,6 +23,5 @@ import (
 
 type ManagementGroup struct {
 	azure.ManagementGroup
-	TenantId   string `json:"tenantId"`
-	TenantName string `json:"tenantName"`
+	TenantId string `json:"tenantId"`
 }


### PR DESCRIPTION
https://specterops.atlassian.net/browse/BED-4884

The REST API for management groups and subscriptions properly returns a tenant ID as part of its properties. AzureHound is incorrectly using the tenant info in the client, which leads to improper tenant hierarchy on the API side. This PR corrects this discrepancy and uses the correct tenant info.

As part of this work, all AzureRM resources were validated to ensure this mistake wasn't made in other spots