### PR TITLE
cd: publish stable images to azure container registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -175,7 +175,7 @@ jobs:
         with:
           images: |
             ghcr.io/bloodhoundad/azurehound
-            azurehoundregistry.azurecr.io/azurehound
+            ${{ secrets.ACR_AZUREHOUND_REGISTRY_URL }}/azurehound
           tags: |
             type=semver,pattern={{version}},prefix=v
             type=semver,pattern={{major}}.{{minor}},prefix=v

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -155,18 +155,27 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Log in to the Container registry
+      - name: Log in to GHCR
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
           registry: ghcr.io
           username: ${{ secrets.GHCR_USER }}
           password: ${{ secrets.PACKAGE_SCOPE }}
 
+      - name: Log in to ACR
+        uses: azure/docker-login@v1
+        with:
+          login-server: ${{ secrets.ACR_AZUREHOUND_REGISTRY_URL }}
+          username: ${{ secrets.ACR_CLIENT_ID }}
+          password: ${{ secrets.ACR_SECRET }}
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: ghcr.io/bloodhoundad/azurehound
+          images: |
+            ghcr.io/bloodhoundad/azurehound
+            azurehoundregistry.azurecr.io/azurehound
           tags: |
             type=semver,pattern={{version}},prefix=v
             type=semver,pattern={{major}}.{{minor}},prefix=v


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated workflow to support publishing images to both GitHub Container Registry (GHCR) and Azure Container Registry (ACR).
  * Added authentication steps for ACR in the publishing process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->