### PR TITLE
BED-5717 Fix Resetting Connections

### DIFF
--- a/client/bloodhound/client.go
+++ b/client/bloodhound/client.go
@@ -79,6 +79,8 @@ func NewBHEClient(bheUrl url.URL, tokenId, token, proxy string, maxReqPerConn, m
 		proxy:               proxy,
 		retryDelay:          5,
 		log:                 logger,
+		token:               token,
+		tokenId:             tokenId,
 	}, nil
 }
 
@@ -400,6 +402,8 @@ func (s *BHEClient) resetConnection() error {
 		token:     s.token,
 		signature: BHEAuthSignature,
 	}
+
+	s.log.V(1).Info("Max requests per connection limit reached, resetting connection with BHE server")
 
 	s.httpClient.CloseIdleConnections()
 

--- a/client/bloodhound/client.go
+++ b/client/bloodhound/client.go
@@ -419,9 +419,10 @@ func (s *BHEClient) resetConnection() error {
 func (s *BHEClient) incrementRequest() error {
 	s.mu.Lock()
 	s.currentRequestCount += 1
+	needsReset := s.currentRequestCount >= s.requestLimit
 	s.mu.Unlock()
 
-	if s.currentRequestCount >= s.requestLimit {
+	if needsReset {
 		if err := s.resetConnection(); err != nil {
 			s.log.Error(err, "error resetting BHE http client connection")
 			return err

--- a/client/bloodhound/client_test.go
+++ b/client/bloodhound/client_test.go
@@ -44,6 +44,7 @@ func TestBHEClient_SendRequest(t *testing.T) {
 			requestCount++
 			w.WriteHeader(http.StatusInternalServerError)
 		}))
+		defer testServer.Close()
 
 		testUrl, _ := url.Parse(testServer.URL)
 
@@ -66,6 +67,7 @@ func TestBHEClient_Ingest(t *testing.T) {
 		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusAccepted)
 		}))
+		defer testServer.Close()
 
 		testUrl, _ := url.Parse(testServer.URL)
 
@@ -85,13 +87,14 @@ func TestBHEClient_Ingest(t *testing.T) {
 		requestCount := 0
 		maxRetries := 1
 		wg := sync.WaitGroup{}
-		wg.Add(2)
+		wg.Add(maxRetries + 1)
 
 		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer wg.Done()
 			requestCount++
 			w.WriteHeader(http.StatusGatewayTimeout)
-			wg.Done()
 		}))
+		defer testServer.Close()
 
 		testUrl, _ := url.Parse(testServer.URL)
 


### PR DESCRIPTION
A bug was found when resetting connections due to improperly storing the `tokenid` and `token` of the BHE client
This also adds an additional information log when the client resets a connection with the BHE server

Tested locally by setting the `maxreqsperconn` settings to a low number (50) to replicate the issue and ensured AzureHound could re-connect to the `test` instance after the connection was reset

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication credentials are now correctly applied during client initialization, reducing auth failures.
* **Chores**
  * Adds an informational log when a connection is reset after reaching the max requests per connection to improve observability.
* **Tests**
  * Adds synchronization to retry tests to reliably verify retry behavior and exact request counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->