### PR TITLE
Add a global flag to customize the User-Agent

### DIFF
--- a/client/rest/http.go
+++ b/client/rest/http.go
@@ -128,8 +128,13 @@ func NewRequest(
 			req.Header.Set("Accept", "application/json")
 		}
 
-		// set azurehound as user-agent
-		req.Header.Set("User-Agent", constants.UserAgent())
+		// set azurehound as user-agent, use custom if set in config
+		ua := config.UserAgent.Value()
+		if s, ok := ua.(string); ok && s != "" {
+			req.Header.Set("User-Agent", s)
+		} else {
+			req.Header.Set("User-Agent", constants.UserAgent())
+		}
 		return req, nil
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -355,6 +355,14 @@ var (
 		Default:    "",
 	}
 
+	UserAgent = Config{
+		Name:       "user-agent",
+		Shorthand:  "U",
+		Usage:      "Custom User-Agent header",
+		Persistent: true,
+		Default:    "",
+	}
+
 	GlobalConfig = []Config{
 		ConfigFile,
 		VerbosityLevel,
@@ -364,6 +372,7 @@ var (
 		Proxy,
 		RefreshToken,
 		Pprof,
+		UserAgent,
 	}
 
 	AzureConfig = []Config{


### PR DESCRIPTION
**Motivation**

Previously, the User-Agent used by AzureHound was hardcoded and could only be changed by recompiling the binary.
This PR introduces a simple way to set a custom User-Agent at runtime using the --user-agent (-U) flag, making it easier for evasion or for debugging/identification purposes.

**Main changes**

- Added a global --user-agent (-U) flag in the CLI configuration (config.go).
- All HTTP requests now use the custom User-Agent if the flag is set; otherwise, they fall back to the default (constants-based) value.

**Results**

<img width="1271" height="536" alt="Capture d'écran 2025-10-07 105641" src="https://github.com/user-attachments/assets/cf29f0fb-f460-4c09-9d4f-ac2d0b522b2c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a custom User-Agent header applied to all HTTP requests.
  * Configure via the new "user-agent" setting or the -U command-line flag; the value is persisted across runs.
  * If not specified, the existing default User-Agent remains in effect.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->