### PR TITLE
fix(BED-6314): fix --jwt code path

### DIFF
--- a/client/rest/auth.go
+++ b/client/rest/auth.go
@@ -347,5 +347,6 @@ func (s *ManagedIdentitySDKAuthStrategy) isExpired() bool {
 }
 
 func (s *ManagedIdentitySDKAuthStrategy) isJWTProvided() bool {
+	// Not used in SDK-based flow, do nothing
 	return false
 }


### PR DESCRIPTION
This PR addresses a bug preventing the use of JWT authentication for AzureHound. 

During a refactor introducing `AuthStrategy` (which is great) there was a small change in the code flow that no longer checked for a JWT before attempting to refresh authentication, causing an error during said auth refresh because there wouldn't be any other valid creds.

closes: #122

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents unnecessary token refresh attempts when a valid JWT is provided, reducing latency and potential authentication errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->