### PR TITLE
chores: Add a step to scan AzureHound Build Image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,6 +161,7 @@ jobs:
           build-args: VERSION=v0.0.0-rolling+${{ github.sha }}
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          push: ${{ ! startsWith(github.event_name, 'pull_request') }}
           secrets: |
             GIT_AUTH_TOKEN=${{ secrets.PACKAGE_SCOPE }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,12 @@ jobs:
           tags: |
             type=edge,branch=main
             type=sha,prefix=edge-,format=short
+      
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Build Container Image
         uses: docker/build-push-action@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,9 +76,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          provenance: mode=max
           secrets: |
             GIT_AUTH_TOKEN=${{ secrets.PACKAGE_SCOPE }}
           # Multi-plaform builds can not be loaded into local Docker Daemon 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,18 @@ jobs:
           push: ${{ ! startsWith(github.event_name, 'pull_request') }}
           secrets: |
             GIT_AUTH_TOKEN=${{ secrets.PACKAGE_SCOPE }}
+          outputs: 'type=local dest=/tmp/azurehound.tar'
+
+      - name: Trivy scan for vulnerabilities
+        id: trivy_amd64
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
+        with:
+          input: /tmp/azurehound.tar
+          format: "json"
+          severity: "HIGH,CRITICAL"
+          ignore-unfixed: true
+          cache-dir: /tmp/trivy-cache
+          output: /tmp/trivy-report-amd64.json
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,24 +70,42 @@ jobs:
       - name: Build Container Image
         uses: docker/build-push-action@v6
         with:
+          platforms: "linux/amd64,linux/arm64"
           context: .
           build-args: VERSION=v0.0.0-rolling+${{ github.sha }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          push: ${{ ! startsWith(github.event_name, 'pull_request') }}
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: mode=max
           secrets: |
             GIT_AUTH_TOKEN=${{ secrets.PACKAGE_SCOPE }}
-          outputs: type=tar,dest=azurehound.tar
+          # Multi-plaform builds can not be loaded into local Docker Daemon 
+          # Must use an Open Container Image to scan for vulnerabilities.
+          outputs: type=oci,dest=/tmp/oci-image.tar
 
-      - name: Trivy scan for vulnerabilities
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
+      - name: Upload OCI tarball
+        uses: actions/upload-artifact@v4
         with:
-          input: azurehound.tar
-          format: "json"
-          severity: "HIGH,CRITICAL"
-          ignore-unfixed: true
-          cache-dir: /tmp/trivy-cache
-          output: /tmp/trivy-report-azurehound.json
+          name: oci-image-tar
+          path: /tmp/oci-image.tar
+
+      # Convert OCI Directory to Docker-compatible tars for amd64 and arm64
+      - name: Convert OCI to Docker tarballs (amd64 + arm64)
+        run: |
+          set -euo pipefail
+          for arch in amd64 arm64; do
+            echo "Converting $arch image..."
+
+            if ! skopeo copy \
+              --override-arch=$arch --override-os=linux \
+              oci-archive:/tmp/oci-image.tar \
+              docker-archive:/tmp/converted-$arch.tar; then
+              echo "skopeo copy failed for $arch"
+              exit 1
+            fi
+          done
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,10 +76,9 @@ jobs:
       - name: Build Container Image
         uses: docker/build-push-action@v6
         with:
-          platforms: "linux/amd64,linux/arm64"
           context: .
           build-args: VERSION=v0.0.0-rolling+${{ github.sha }}
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: azurehound # temporary tag to simplify oci conversion
           labels: ${{ steps.meta.outputs.labels }}
           push: false
           secrets: |
@@ -94,21 +93,66 @@ jobs:
           name: oci-image-tar
           path: /tmp/oci-image.tar
 
-      # Convert OCI Directory to Docker-compatible tars for amd64 and arm64
-      - name: Convert OCI to Docker tarballs (amd64 + arm64)
+      # Convert OCI Directory to Docker-compatible tar for amd64
+      - name: Convert OCI to Docker tarball
         run: |
           set -euo pipefail
-          for arch in amd64 arm64; do
-            echo "Converting $arch image..."
+          echo "Converting amd64 image..."
 
-            if ! skopeo copy \
-              --override-arch=$arch --override-os=linux \
-              oci-archive:/tmp/oci-image.tar \
-              docker-archive:/tmp/converted-$arch.tar; then
-              echo "skopeo copy failed for $arch"
+          if ! skopeo copy \
+            --override-arch=amd64 --override-os=linux \
+            oci-archive:/tmp/oci-image.tar \
+            docker-archive:/tmp/converted-amd64.tar; then
+            echo "skopeo copy failed for amd64"
+            exit 1
+          fi
+      
+      - name: Trivy scan for vulnerabilities (AMD64)
+        id: trivy_amd64
+        uses: aquasecurity/trivy-action@0.33.1
+        with:
+          input: /tmp/converted-amd64.tar
+          format: "json"
+          severity: "HIGH,CRITICAL"
+          ignore-unfixed: true
+          cache-dir: /tmp/trivy-cache
+          output: /tmp/trivy-report-amd64.json
+
+      - name: Upload Trivy scan reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-scan-reports
+          path: /tmp/trivy-report-amd64.json
+    
+      - name: Check Trivy Report for HIGH/CRITICAL vulnerabilities (amd64 only)
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+        run: |
+          echo "Checking Trivy report for HIGH/CRITICAL vulnerabilities (amd64 only)..."
+
+          # Ensure report exists
+          if [ ! -f /tmp/trivy-report-amd64.json ]; then
+            echo "Error: /tmp/trivy-report-amd64.json not found!"
+            exit 1
+          fi
+
+          # Count vulnerabilities from amd64 report
+          total_vulns=$(jq '[.Results[].Vulnerabilities[]? | select(.Severity=="HIGH" or .Severity=="CRITICAL")] | length' /tmp/trivy-report-amd64.json)
+
+          echo "Event: $GITHUB_EVENT_NAME"
+          echo "Total HIGH/CRITICAL vulnerabilities: $total_vulns"
+
+          if [ "$total_vulns" -gt 0 ]; then
+            # Fail only on push events
+            if [ "$GITHUB_EVENT_NAME" = "push" ]; then
+              echo "Push event detected. Failing the job to block image push."
               exit 1
+            else
+              echo "Pull request event. Vulnerabilities found, but continuing (non-blocking)."
             fi
-          done
+          else
+            echo "No HIGH/CRITICAL vulnerabilities found. Safe to proceed."
+          fi
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
           push: ${{ ! startsWith(github.event_name, 'pull_request') }}
           secrets: |
             GIT_AUTH_TOKEN=${{ secrets.PACKAGE_SCOPE }}
-          outputs: type=tar dest=azurehound.tar
+          outputs: type=tar,dest=azurehound.tar
 
       - name: Trivy scan for vulnerabilities
         uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
           push: ${{ ! startsWith(github.event_name, 'pull_request') }}
           secrets: |
             GIT_AUTH_TOKEN=${{ secrets.PACKAGE_SCOPE }}
-          outputs: 'type=tar dest=azurehound.tar'
+          outputs: type=tar dest=azurehound.tar
 
       - name: Trivy scan for vulnerabilities
         uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,6 +153,16 @@ jobs:
           else
             echo "No HIGH/CRITICAL vulnerabilities found. Safe to proceed."
           fi
+                
+      - name: Push Image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          build-args: VERSION=v0.0.0-rolling+${{ github.sha }}
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          secrets: |
+            GIT_AUTH_TOKEN=${{ secrets.PACKAGE_SCOPE }}
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
           push: ${{ ! startsWith(github.event_name, 'pull_request') }}
           secrets: |
             GIT_AUTH_TOKEN=${{ secrets.PACKAGE_SCOPE }}
-          outputs: 'type=local dest=/tmp/azurehound.tar'
+          outputs: 'type=tar dest=/tmp/azurehound.tar'
 
       - name: Trivy scan for vulnerabilities
         id: trivy_amd64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,18 +77,17 @@ jobs:
           push: ${{ ! startsWith(github.event_name, 'pull_request') }}
           secrets: |
             GIT_AUTH_TOKEN=${{ secrets.PACKAGE_SCOPE }}
-          outputs: 'type=tar dest=/tmp/azurehound.tar'
+          outputs: 'type=tar dest=azurehound.tar'
 
       - name: Trivy scan for vulnerabilities
-        id: trivy_amd64
         uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
         with:
-          input: /tmp/azurehound.tar
+          input: azurehound.tar
           format: "json"
           severity: "HIGH,CRITICAL"
           ignore-unfixed: true
           cache-dir: /tmp/trivy-cache
-          output: /tmp/trivy-report-amd64.json
+          output: /tmp/trivy-report-azurehound.json
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
       
       - name: Trivy scan for vulnerabilities (AMD64)
         id: trivy_amd64
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
         with:
           input: /tmp/converted-amd64.tar
           format: "json"
@@ -159,7 +159,7 @@ jobs:
         with:
           context: .
           build-args: VERSION=v0.0.0-rolling+${{ github.sha }}
-          tags: ${{ steps.metadata.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: ${{ ! startsWith(github.event_name, 'pull_request') }}
           secrets: |

--- a/.github/workflows/vuln-scan.yml
+++ b/.github/workflows/vuln-scan.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run vulnerability scanner
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
         with:
           scan-type: 'repo'
           scan-ref: './'


### PR DESCRIPTION
Closes:BED-6803

- Append a Step to scan AzureHound build image using [Trivy GH Action](https://github.com/aquasecurity/trivy-action)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added QEMU and Buildx setup, building images as OCI tarballs instead of direct pushes.
  * Convert OCI artifacts to Docker-compatible tarballs for amd64 using skopeo.
  * Store OCI images and converted tarballs as downloadable artifacts.
  * Introduced Trivy vulnerability scanning (pinned version), upload JSON reports; HIGH/CRITICAL blocks push events but is non-blocking for PRs.
  * Separated and gated final image push into a dedicated step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->