### PR TITLE
[BED-6605] Allow negative serials for x509 certificate verification

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,6 +18,8 @@
 //go:build !windows
 // +build !windows
 
+//go:debug x509negativeserial=1
+
 package main
 
 import (


### PR DESCRIPTION
Prior to Go 1.23, negative serial numbers were allowed in certificates.  Some clients are reporting errors using Azurehound in their proxy environments under their current configurations.  We can relax our need for perfectly compliant certificates here to accommodate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added build-time configuration for enhanced certificate handling on non-Windows platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->