### PR TITLE
feat: Remove Azure Germany region from AzureHound configuration BED-4601

### DIFF
--- a/client/config/config.go
+++ b/client/config/config.go
@@ -51,8 +51,6 @@ func AuthorityUrl(region string, defaultUrl string) string {
 		return constants.AzureChina().ActiveDirectoryAuthority
 	case constants.Cloud:
 		return constants.AzureCloud().ActiveDirectoryAuthority
-	case constants.Germany:
-		return constants.AzureGermany().ActiveDirectoryAuthority
 	case constants.USGovL4:
 		return constants.AzureUSGovernment().ActiveDirectoryAuthority
 	case constants.USGovL5:
@@ -72,8 +70,6 @@ func GraphUrl(region string, defaultUrl string) string {
 		return constants.AzureChina().MicrosoftGraphUrl
 	case constants.Cloud:
 		return constants.AzureCloud().MicrosoftGraphUrl
-	case constants.Germany:
-		return constants.AzureGermany().MicrosoftGraphUrl
 	case constants.USGovL4:
 		return constants.AzureUSGovernment().MicrosoftGraphUrl
 	case constants.USGovL5:
@@ -93,8 +89,6 @@ func ResourceManagerUrl(region string, defaultUrl string) string {
 		return constants.AzureChina().ResourceManagerUrl
 	case constants.Cloud:
 		return constants.AzureCloud().ResourceManagerUrl
-	case constants.Germany:
-		return constants.AzureGermany().ResourceManagerUrl
 	case constants.USGovL4:
 		return constants.AzureUSGovernment().ResourceManagerUrl
 	case constants.USGovL5:

--- a/config/config.go
+++ b/config/config.go
@@ -72,7 +72,6 @@ const EnvPrefix string = "AZUREHOUND"
 var AzRegions = []string{
 	constants.China,
 	constants.Cloud,
-	constants.Germany,
 	constants.USGovL4,
 	constants.USGovL5,
 }

--- a/constants/environments.go
+++ b/constants/environments.go
@@ -21,7 +21,6 @@ package constants
 const (
 	China   string = "china"
 	Cloud   string = "cloud"
-	Germany string = "germany"
 	USGovL4 string = "usgovl4"
 	USGovL5 string = "usgovl5"
 )
@@ -59,13 +58,5 @@ func AzureChina() Environment {
 		"https://login.chinacloudapi.cn",
 		"https://microsoftgraph.chinacloudapi.cn",
 		"https://management.chinacloudapi.cn",
-	}
-}
-
-func AzureGermany() Environment {
-	return Environment{
-		"https://login.microsoftonline.de",
-		"https://graph.microsoft.de",
-		"https://management.microsoftazure.de",
 	}
 }


### PR DESCRIPTION
- Removes Germany and AzureGermany() constant from /client/config directory, and from environments file
- evidence that Germany is removed:
<img width="577" height="168" alt="bed_4601_2" src="https://github.com/user-attachments/assets/c74aaf66-6f30-4a52-8845-193b66720d46" />

Closes: BED-4601

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed support for the Germany Azure region. Germany is no longer available as a configuration option and has been removed from environment endpoints and region settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->