### PR TITLE
BED-4602: Reduce Verbose Log Output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,7 @@ $RECYCLE.BIN/
 
 # Plugin metadata
 .idea/**/go.imports.xml
+.idea/**/material_theme_project_new.xml
 
 # Sensitive or high-churn files
 .idea/**/dataSources/

--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,9 @@ $RECYCLE.BIN/
 # Generated files
 .idea/**/contentModel.xml
 
+# Plugin metadata
+.idea/**/go.imports.xml
+
 # Sensitive or high-churn files
 .idea/**/dataSources/
 .idea/**/dataSources.ids

--- a/cmd/list-app-owners.go
+++ b/cmd/list-app-owners.go
@@ -89,7 +89,7 @@ func listAppOwners(ctx context.Context, client client.AzureClient, apps <-chan a
 							Owner: item.Ok,
 							AppId: app.Data.Id,
 						}
-						log.V(2).Info("found app owner", "appOwner", appOwner)
+						log.V(2).Info("found app owner", "appId", appOwner.AppId)
 						count++
 						data.Owners = append(data.Owners, appOwner)
 					}

--- a/cmd/list-app-role-assignments.go
+++ b/cmd/list-app-role-assignments.go
@@ -102,7 +102,7 @@ func listAppRoleAssignments(ctx context.Context, client client.AzureClient, serv
 					if item.Error != nil {
 						log.Error(item.Error, "unable to continue processing app role assignments for this service principal", "servicePrincipalId", servicePrincipal)
 					} else {
-						log.V(2).Info("found app role assignment", "roleAssignments", item)
+						log.V(2).Info("found app role assignment", "id", item.Ok.Id, "appRoleId", item.Ok.AppRoleId, "name", item.Ok.ResourceDisplayName)
 						count++
 						if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
 							Kind: enums.KindAZAppRoleAssignment,

--- a/cmd/list-app-role-assignments.go
+++ b/cmd/list-app-role-assignments.go
@@ -102,7 +102,7 @@ func listAppRoleAssignments(ctx context.Context, client client.AzureClient, serv
 					if item.Error != nil {
 						log.Error(item.Error, "unable to continue processing app role assignments for this service principal", "servicePrincipalId", servicePrincipal)
 					} else {
-						log.V(2).Info("found app role assignment", "id", item.Ok.Id, "appRoleId", item.Ok.AppRoleId, "name", item.Ok.ResourceDisplayName)
+						log.V(2).Info("found app role assignment", "appRoleId", item.Ok.AppRoleId)
 						count++
 						if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
 							Kind: enums.KindAZAppRoleAssignment,

--- a/cmd/list-apps.go
+++ b/cmd/list-apps.go
@@ -70,7 +70,7 @@ func listApps(ctx context.Context, client client.AzureClient) <-chan azureWrappe
 				log.Error(item.Error, "unable to continue processing applications")
 				return
 			} else {
-				log.V(2).Info("found application", "app", item)
+				log.V(2).Info("found application", "id", item.Ok.AppId, "name", item.Ok.DisplayName)
 				count++
 				if ok := pipeline.Send(ctx.Done(), out, NewAzureWrapper(
 					enums.KindAZApp,

--- a/cmd/list-automation-account-role-assignments.go
+++ b/cmd/list-automation-account-role-assignments.go
@@ -110,7 +110,7 @@ func listAutomationAccountRoleAssignments(ctx context.Context, client client.Azu
 							ObjectId:         id,
 							RoleDefinitionId: roleDefinitionId,
 						}
-						log.V(2).Info("found automation account role assignment", "automationAccountRoleAssignment", automationAccountRoleAssignment)
+						log.V(2).Info("found automation account role assignment", "id", automationAccountRoleAssignment.ObjectId, "roleDefinitionId", automationAccountRoleAssignment.RoleDefinitionId)
 						count++
 						automationAccountRoleAssignments.RoleAssignments = append(automationAccountRoleAssignments.RoleAssignments, automationAccountRoleAssignment)
 					}

--- a/cmd/list-automation-account-role-assignments.go
+++ b/cmd/list-automation-account-role-assignments.go
@@ -110,7 +110,7 @@ func listAutomationAccountRoleAssignments(ctx context.Context, client client.Azu
 							ObjectId:         id,
 							RoleDefinitionId: roleDefinitionId,
 						}
-						log.V(2).Info("found automation account role assignment", "id", automationAccountRoleAssignment.ObjectId, "roleDefinitionId", automationAccountRoleAssignment.RoleDefinitionId)
+						log.V(2).Info("found automation account role assignment", "roleDefinitionId", automationAccountRoleAssignment.RoleDefinitionId)
 						count++
 						automationAccountRoleAssignments.RoleAssignments = append(automationAccountRoleAssignments.RoleAssignments, automationAccountRoleAssignment)
 					}

--- a/cmd/list-automation-accounts.go
+++ b/cmd/list-automation-accounts.go
@@ -102,7 +102,7 @@ func listAutomationAccounts(ctx context.Context, client client.AzureClient, subs
 							ResourceGroupId:   resourceGroupId,
 							TenantId:          client.TenantInfo().TenantId,
 						}
-						log.V(2).Info("found automation account", "id", automationAccount.Id, "name", automationAccount.Name)
+						log.V(2).Info("found automation account", "name", automationAccount.Name)
 						count++
 						if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
 							Kind: enums.KindAZAutomationAccount,

--- a/cmd/list-automation-accounts.go
+++ b/cmd/list-automation-accounts.go
@@ -102,7 +102,7 @@ func listAutomationAccounts(ctx context.Context, client client.AzureClient, subs
 							ResourceGroupId:   resourceGroupId,
 							TenantId:          client.TenantInfo().TenantId,
 						}
-						log.V(2).Info("found automation account", "automationAccount", automationAccount)
+						log.V(2).Info("found automation account", "id", automationAccount.Id, "name", automationAccount.Name)
 						count++
 						if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
 							Kind: enums.KindAZAutomationAccount,

--- a/cmd/list-container-registries.go
+++ b/cmd/list-container-registries.go
@@ -107,7 +107,7 @@ func listContainerRegistries(ctx context.Context, client client.AzureClient, sub
 							ResourceGroupId:   resourceGroupId,
 							TenantId:          client.TenantInfo().TenantId,
 						}
-						log.V(2).Info("found container registry", "id", containerRegistry.Id, "name", containerRegistry.Name)
+						log.V(2).Info("found container registry", "name", containerRegistry.Name)
 						count++
 						if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
 							Kind: enums.KindAZContainerRegistry,

--- a/cmd/list-container-registries.go
+++ b/cmd/list-container-registries.go
@@ -107,7 +107,7 @@ func listContainerRegistries(ctx context.Context, client client.AzureClient, sub
 							ResourceGroupId:   resourceGroupId,
 							TenantId:          client.TenantInfo().TenantId,
 						}
-						log.V(2).Info("found container registry", "containerRegistry", containerRegistry)
+						log.V(2).Info("found container registry", "id", containerRegistry.Id, "name", containerRegistry.Name)
 						count++
 						if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
 							Kind: enums.KindAZContainerRegistry,

--- a/cmd/list-container-registry-role-assignments.go
+++ b/cmd/list-container-registry-role-assignments.go
@@ -115,7 +115,7 @@ func listContainerRegistryRoleAssignments(ctx context.Context, client client.Azu
 							ObjectId:         id,
 							RoleDefinitionId: roleDefinitionId,
 						}
-						log.V(2).Info("found container registry role assignment", "id", id, "principalId", item.Ok.GetPrincipalId(), "roleDefinitionId", containerRegistryRoleAssignment.RoleDefinitionId, "scope", containerRegistryRoleAssignment.Assignee.Properties.Scope)
+						log.V(2).Info("found container registry role assignment", "roleDefinitionId", roleDefinitionId)
 						count++
 						containerRegistryRoleAssignments.RoleAssignments = append(containerRegistryRoleAssignments.RoleAssignments, containerRegistryRoleAssignment)
 					}

--- a/cmd/list-container-registry-role-assignments.go
+++ b/cmd/list-container-registry-role-assignments.go
@@ -115,7 +115,7 @@ func listContainerRegistryRoleAssignments(ctx context.Context, client client.Azu
 							ObjectId:         id,
 							RoleDefinitionId: roleDefinitionId,
 						}
-						log.V(2).Info("found container registry role assignment", "containerRegistryRoleAssignment", containerRegistryRoleAssignment)
+						log.V(2).Info("found container registry role assignment", "id", id, "principalId", item.Ok.GetPrincipalId(), "roleDefinitionId", containerRegistryRoleAssignment.RoleDefinitionId, "scope", containerRegistryRoleAssignment.Assignee.Properties.Scope)
 						count++
 						containerRegistryRoleAssignments.RoleAssignments = append(containerRegistryRoleAssignments.RoleAssignments, containerRegistryRoleAssignment)
 					}

--- a/cmd/list-device-owners.go
+++ b/cmd/list-device-owners.go
@@ -105,7 +105,7 @@ func listDeviceOwners(ctx context.Context, client client.AzureClient, devices <-
 							Owner:    item.Ok,
 							DeviceId: id,
 						}
-						log.V(2).Info("found device owner", "deviceOwner", deviceOwner)
+						log.V(2).Info("found device owner", "deviceId", deviceOwner.DeviceId)
 						count++
 						data.Owners = append(data.Owners, deviceOwner)
 					}

--- a/cmd/list-devices.go
+++ b/cmd/list-devices.go
@@ -70,7 +70,7 @@ func listDevices(ctx context.Context, client client.AzureClient) <-chan interfac
 				log.Error(item.Error, "unable to continue processing devices")
 				return
 			} else {
-				log.V(2).Info("found device", "device", item)
+				log.V(2).Info("found device", "deviceId", item.Ok.DeviceId)
 				count++
 				if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
 					Kind: enums.KindAZDevice,

--- a/cmd/list-function-app-role-assignments.go
+++ b/cmd/list-function-app-role-assignments.go
@@ -110,7 +110,7 @@ func listFunctionAppRoleAssignments(ctx context.Context, client client.AzureClie
 							ObjectId:         id,
 							RoleDefinitionId: roleDefinitionId,
 						}
-						log.V(2).Info("Found function app role assignment", "id", id, "roleDefinitionId", roleDefinitionId, "principalId", functionAppRoleAssignment.Assignee.Properties.PrincipalId, "scope", functionAppRoleAssignment.Assignee.Properties.Scope)
+						log.V(2).Info("Found function app role assignment", "roleDefinitionId", roleDefinitionId)
 						count++
 						functionAppRoleAssignments.RoleAssignments = append(functionAppRoleAssignments.RoleAssignments, functionAppRoleAssignment)
 					}

--- a/cmd/list-function-app-role-assignments.go
+++ b/cmd/list-function-app-role-assignments.go
@@ -110,7 +110,7 @@ func listFunctionAppRoleAssignments(ctx context.Context, client client.AzureClie
 							ObjectId:         id,
 							RoleDefinitionId: roleDefinitionId,
 						}
-						log.V(2).Info("Found function app role asignment", "functionAppRoleAssignment", functionAppRoleAssignment)
+						log.V(2).Info("Found function app role assignment", "id", id, "roleDefinitionId", roleDefinitionId, "principalId", functionAppRoleAssignment.Assignee.Properties.PrincipalId, "scope", functionAppRoleAssignment.Assignee.Properties.Scope)
 						count++
 						functionAppRoleAssignments.RoleAssignments = append(functionAppRoleAssignments.RoleAssignments, functionAppRoleAssignment)
 					}

--- a/cmd/list-function-apps.go
+++ b/cmd/list-function-apps.go
@@ -103,7 +103,7 @@ func listFunctionApps(ctx context.Context, client client.AzureClient, subscripti
 							TenantId:          client.TenantInfo().TenantId,
 						}
 						if functionApp.Kind == "functionapp" {
-							log.V(2).Info("found function app", "id", functionApp.Id, "name", functionApp.Name)
+							log.V(2).Info("found function app", "name", functionApp.Name)
 							count++
 							if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
 								Kind: enums.KindAZFunctionApp,

--- a/cmd/list-function-apps.go
+++ b/cmd/list-function-apps.go
@@ -103,7 +103,7 @@ func listFunctionApps(ctx context.Context, client client.AzureClient, subscripti
 							TenantId:          client.TenantInfo().TenantId,
 						}
 						if functionApp.Kind == "functionapp" {
-							log.V(2).Info("found function app", "functionApp", functionApp)
+							log.V(2).Info("found function app", "id", functionApp.Id, "name", functionApp.Name)
 							count++
 							if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
 								Kind: enums.KindAZFunctionApp,

--- a/cmd/list-group-members.go
+++ b/cmd/list-group-members.go
@@ -116,7 +116,7 @@ func listGroupMembers(ctx context.Context, client client.AzureClient, groups <-c
 							Member:  item.Ok,
 							GroupId: id,
 						}
-						log.V(2).Info("found group member", "groupMember", groupMember)
+						log.V(2).Info("found group member", "groupId", groupMember.GroupId)
 						count++
 						data.Members = append(data.Members, groupMember)
 					}

--- a/cmd/list-group-owners.go
+++ b/cmd/list-group-owners.go
@@ -106,7 +106,7 @@ func listGroupOwners(ctx context.Context, client client.AzureClient, groups <-ch
 							Owner:   item.Ok,
 							GroupId: id,
 						}
-						log.V(2).Info("found group owner", "groupOwner", groupOwner)
+						log.V(2).Info("found group owner", "groupId", groupOwner.GroupId)
 						count++
 						groupOwners.Owners = append(groupOwners.Owners, groupOwner)
 					}

--- a/cmd/list-groups.go
+++ b/cmd/list-groups.go
@@ -70,7 +70,7 @@ func listGroups(ctx context.Context, client client.AzureClient) <-chan interface
 				log.Error(item.Error, "unable to continue processing groups")
 				return
 			} else {
-				log.V(2).Info("found group", "group", item)
+				log.V(2).Info("found group", "id", item.Ok.Id, "name", item.Ok.DisplayName)
 				count++
 				group := models.Group{
 					Group:      item.Ok,

--- a/cmd/list-groups.go
+++ b/cmd/list-groups.go
@@ -70,7 +70,7 @@ func listGroups(ctx context.Context, client client.AzureClient) <-chan interface
 				log.Error(item.Error, "unable to continue processing groups")
 				return
 			} else {
-				log.V(2).Info("found group", "id", item.Ok.Id, "name", item.Ok.DisplayName)
+				log.V(2).Info("found group", "name", item.Ok.DisplayName)
 				count++
 				group := models.Group{
 					Group:      item.Ok,

--- a/cmd/list-key-vault-role-assignments.go
+++ b/cmd/list-key-vault-role-assignments.go
@@ -106,7 +106,7 @@ func listKeyVaultRoleAssignments(ctx context.Context, client client.AzureClient,
 							KeyVaultId:     id,
 							RoleAssignment: item.Ok,
 						}
-						log.V(2).Info("found key vault role assignment", "keyVaultRoleAssignment", keyVaultRoleAssignment)
+						log.V(2).Info("found key vault role assignment", "id", keyVaultRoleAssignment.RoleAssignment.Id, "keyVaultId", keyVaultRoleAssignment.KeyVaultId)
 						count++
 						keyVaultRoleAssignments.RoleAssignments = append(keyVaultRoleAssignments.RoleAssignments, keyVaultRoleAssignment)
 					}

--- a/cmd/list-key-vault-role-assignments.go
+++ b/cmd/list-key-vault-role-assignments.go
@@ -106,7 +106,7 @@ func listKeyVaultRoleAssignments(ctx context.Context, client client.AzureClient,
 							KeyVaultId:     id,
 							RoleAssignment: item.Ok,
 						}
-						log.V(2).Info("found key vault role assignment", "id", keyVaultRoleAssignment.RoleAssignment.Id, "keyVaultId", keyVaultRoleAssignment.KeyVaultId)
+						log.V(2).Info("found key vault role assignment", "name", keyVaultRoleAssignment.RoleAssignment.Name)
 						count++
 						keyVaultRoleAssignments.RoleAssignments = append(keyVaultRoleAssignments.RoleAssignments, keyVaultRoleAssignment)
 					}

--- a/cmd/list-key-vaults.go
+++ b/cmd/list-key-vaults.go
@@ -105,7 +105,7 @@ func listKeyVaults(ctx context.Context, client client.AzureClient, subscriptions
 							ResourceGroup:  item.Ok.ResourceGroupId(),
 							TenantId:       item.Ok.Properties.TenantId,
 						}
-						log.V(2).Info("found key vault", "id", keyVault.Id, "name", keyVault.Name, "tenantId", keyVault.TenantId)
+						log.V(2).Info("found key vault", "name", keyVault.Name)
 						count++
 						if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
 							Kind: enums.KindAZKeyVault,

--- a/cmd/list-key-vaults.go
+++ b/cmd/list-key-vaults.go
@@ -105,7 +105,7 @@ func listKeyVaults(ctx context.Context, client client.AzureClient, subscriptions
 							ResourceGroup:  item.Ok.ResourceGroupId(),
 							TenantId:       item.Ok.Properties.TenantId,
 						}
-						log.V(2).Info("found key vault", "keyVault", keyVault)
+						log.V(2).Info("found key vault", "id", keyVault.Id, "name", keyVault.Name, "tenantId", keyVault.TenantId)
 						count++
 						if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
 							Kind: enums.KindAZKeyVault,

--- a/cmd/list-logic-app-role-assignments.go
+++ b/cmd/list-logic-app-role-assignments.go
@@ -115,7 +115,7 @@ func listLogicAppRoleAssignments(ctx context.Context, client client.AzureClient,
 							ObjectId:         id,
 							RoleDefinitionId: roleDefinitionId,
 						}
-						log.V(2).Info("found logic app role assignment", "logicappRoleAssignment", logicappRoleAssignment)
+						log.V(2).Info("found logic app role assignment", "id", logicappRoleAssignment.ObjectId, "roleDefinitionId", roleDefinitionId)
 						count++
 						logicappRoleAssignments.RoleAssignments = append(logicappRoleAssignments.RoleAssignments, logicappRoleAssignment)
 					}

--- a/cmd/list-logic-app-role-assignments.go
+++ b/cmd/list-logic-app-role-assignments.go
@@ -115,7 +115,7 @@ func listLogicAppRoleAssignments(ctx context.Context, client client.AzureClient,
 							ObjectId:         id,
 							RoleDefinitionId: roleDefinitionId,
 						}
-						log.V(2).Info("found logic app role assignment", "id", logicappRoleAssignment.ObjectId, "roleDefinitionId", roleDefinitionId)
+						log.V(2).Info("found logic app role assignment", "roleDefinitionId", roleDefinitionId)
 						count++
 						logicappRoleAssignments.RoleAssignments = append(logicappRoleAssignments.RoleAssignments, logicappRoleAssignment)
 					}

--- a/cmd/list-logic-apps.go
+++ b/cmd/list-logic-apps.go
@@ -111,7 +111,7 @@ func listLogicApps(ctx context.Context, client client.AzureClient, subscriptions
 							ResourceGroupId: item.Ok.ResourceGroupId(),
 							TenantId:        client.TenantInfo().TenantId,
 						}
-						log.V(2).Info("found logicapp", "id", logicapp.Id, "name", logicapp.Name)
+						log.V(2).Info("found logicapp", "name", logicapp.Name)
 						count++
 						if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
 							Kind: enums.KindAZLogicApp,

--- a/cmd/list-logic-apps.go
+++ b/cmd/list-logic-apps.go
@@ -111,7 +111,7 @@ func listLogicApps(ctx context.Context, client client.AzureClient, subscriptions
 							ResourceGroupId: item.Ok.ResourceGroupId(),
 							TenantId:        client.TenantInfo().TenantId,
 						}
-						log.V(2).Info("found logicapp", "logicapp", logicapp)
+						log.V(2).Info("found logicapp", "id", logicapp.Id, "name", logicapp.Name)
 						count++
 						if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
 							Kind: enums.KindAZLogicApp,

--- a/cmd/list-managed-cluster-role-assignments.go
+++ b/cmd/list-managed-cluster-role-assignments.go
@@ -115,7 +115,7 @@ func listManagedClusterRoleAssignments(ctx context.Context, client client.AzureC
 							ObjectId:         id,
 							RoleDefinitionId: roleDefinitionId,
 						}
-						log.V(2).Info("found managed cluster role assignment", "id", managedClusterRoleAssignment.ObjectId, "roleDefinitionId", managedClusterRoleAssignment.RoleDefinitionId, "principalId", managedClusterRoleAssignment.Assignee.GetPrincipalId())
+						log.V(2).Info("found managed cluster role assignment", "roleDefinitionId", managedClusterRoleAssignment.RoleDefinitionId)
 						count++
 						managedClusterRoleAssignments.RoleAssignments = append(managedClusterRoleAssignments.RoleAssignments, managedClusterRoleAssignment)
 					}

--- a/cmd/list-managed-cluster-role-assignments.go
+++ b/cmd/list-managed-cluster-role-assignments.go
@@ -115,7 +115,7 @@ func listManagedClusterRoleAssignments(ctx context.Context, client client.AzureC
 							ObjectId:         id,
 							RoleDefinitionId: roleDefinitionId,
 						}
-						log.V(2).Info("found managed cluster role assignment", "managedClusterRoleAssignment", managedClusterRoleAssignment)
+						log.V(2).Info("found managed cluster role assignment", "id", managedClusterRoleAssignment.ObjectId, "roleDefinitionId", managedClusterRoleAssignment.RoleDefinitionId, "principalId", managedClusterRoleAssignment.Assignee.GetPrincipalId())
 						count++
 						managedClusterRoleAssignments.RoleAssignments = append(managedClusterRoleAssignments.RoleAssignments, managedClusterRoleAssignment)
 					}

--- a/cmd/list-managed-clusters.go
+++ b/cmd/list-managed-clusters.go
@@ -106,7 +106,7 @@ func listManagedClusters(ctx context.Context, client client.AzureClient, subscri
 							ResourceGroupId: item.Ok.ResourceGroupId(),
 							TenantId:        client.TenantInfo().TenantId,
 						}
-						log.V(2).Info("found managed cluster", "managedCluster", managedCluster)
+						log.V(2).Info("found managed cluster", "id", managedCluster.Id, "name", managedCluster.Name)
 						count++
 						if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
 							Kind: enums.KindAZManagedCluster,

--- a/cmd/list-managed-clusters.go
+++ b/cmd/list-managed-clusters.go
@@ -106,7 +106,7 @@ func listManagedClusters(ctx context.Context, client client.AzureClient, subscri
 							ResourceGroupId: item.Ok.ResourceGroupId(),
 							TenantId:        client.TenantInfo().TenantId,
 						}
-						log.V(2).Info("found managed cluster", "id", managedCluster.Id, "name", managedCluster.Name)
+						log.V(2).Info("found managed cluster", "name", managedCluster.Name)
 						count++
 						if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
 							Kind: enums.KindAZManagedCluster,

--- a/cmd/list-management-group-descendants.go
+++ b/cmd/list-management-group-descendants.go
@@ -96,7 +96,7 @@ func listManagementGroupDescendants(ctx context.Context, client client.AzureClie
 					if item.Error != nil {
 						log.Error(item.Error, "unable to continue processing descendants for this management group", "managementGroupId", id)
 					} else {
-						log.V(2).Info("found management group descendant", "type", item.Ok.Type, "id", item.Ok.Id, "parent", item.Ok.Properties.Parent.Id)
+						log.V(2).Info("found management group descendant", "name", item.Ok.Name)
 						count++
 						if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
 							Kind: enums.KindAZManagementGroupDescendant,

--- a/cmd/list-management-group-role-assignments.go
+++ b/cmd/list-management-group-role-assignments.go
@@ -106,7 +106,7 @@ func listManagementGroupRoleAssignments(ctx context.Context, client client.Azure
 							ManagementGroupId: id,
 							RoleAssignment:    item.Ok,
 						}
-						log.V(2).Info("found managementGroup role assignment", "id", managementGroupRoleAssignment.RoleAssignment.Id, "roleId", managementGroupRoleAssignment.RoleAssignment.Properties.RoleDefinitionId, "principalId", managementGroupRoleAssignment.RoleAssignment.Properties.PrincipalId, "scope", managementGroupRoleAssignment.RoleAssignment.Properties.Scope)
+						log.V(2).Info("found managementGroup role assignment", "name", managementGroupRoleAssignment.RoleAssignment.Name)
 						count++
 						managementGroupRoleAssignments.RoleAssignments = append(managementGroupRoleAssignments.RoleAssignments, managementGroupRoleAssignment)
 					}

--- a/cmd/list-management-group-role-assignments.go
+++ b/cmd/list-management-group-role-assignments.go
@@ -106,7 +106,7 @@ func listManagementGroupRoleAssignments(ctx context.Context, client client.Azure
 							ManagementGroupId: id,
 							RoleAssignment:    item.Ok,
 						}
-						log.V(2).Info("found managementGroup role assignment", "managementGroupRoleAssignment", managementGroupRoleAssignment)
+						log.V(2).Info("found managementGroup role assignment", "id", managementGroupRoleAssignment.RoleAssignment.Id, "roleId", managementGroupRoleAssignment.RoleAssignment.Properties.RoleDefinitionId, "principalId", managementGroupRoleAssignment.RoleAssignment.Properties.PrincipalId, "scope", managementGroupRoleAssignment.RoleAssignment.Properties.Scope)
 						count++
 						managementGroupRoleAssignments.RoleAssignments = append(managementGroupRoleAssignments.RoleAssignments, managementGroupRoleAssignment)
 					}

--- a/cmd/list-management-groups.go
+++ b/cmd/list-management-groups.go
@@ -71,7 +71,7 @@ func listManagementGroups(ctx context.Context, client client.AzureClient) <-chan
 				log.Info("warning: unable to process azure management groups; either the organization has no management groups or azurehound does not have the reader role on the root management group.")
 				return
 			} else if len(config.AzMgmtGroupId.Value().([]string)) == 0 || contains(config.AzMgmtGroupId.Value().([]string), item.Ok.Name) {
-				log.V(2).Info("found management group", "id", item.Ok.Id, "name", item.Ok.Name)
+				log.V(2).Info("found management group", "name", item.Ok.Name)
 				count++
 				mgmtGroup := models.ManagementGroup{
 					ManagementGroup: item.Ok,

--- a/cmd/list-management-groups.go
+++ b/cmd/list-management-groups.go
@@ -71,7 +71,7 @@ func listManagementGroups(ctx context.Context, client client.AzureClient) <-chan
 				log.Info("warning: unable to process azure management groups; either the organization has no management groups or azurehound does not have the reader role on the root management group.")
 				return
 			} else if len(config.AzMgmtGroupId.Value().([]string)) == 0 || contains(config.AzMgmtGroupId.Value().([]string), item.Ok.Name) {
-				log.V(2).Info("found management group", "managementGroup", item)
+				log.V(2).Info("found management group", "id", item.Ok.Id, "name", item.Ok.Name)
 				count++
 				mgmtGroup := models.ManagementGroup{
 					ManagementGroup: item.Ok,

--- a/cmd/list-resource-group-role-assignments.go
+++ b/cmd/list-resource-group-role-assignments.go
@@ -107,7 +107,7 @@ func listResourceGroupRoleAssignments(ctx context.Context, client client.AzureCl
 							ResourceGroupId: id,
 							RoleAssignment:  item.Ok,
 						}
-						log.V(2).Info("found resourceGroup role assignment", "resourceGroupRoleAssignment", resourceGroupRoleAssignment)
+						log.V(2).Info("found resourceGroup role assignment", "id", resourceGroupRoleAssignment.RoleAssignment.Id, "name", resourceGroupRoleAssignment.RoleAssignment.Name, "resourceGroupId", resourceGroupRoleAssignment.ResourceGroupId)
 						count++
 						resourceGroupRoleAssignments.RoleAssignments = append(resourceGroupRoleAssignments.RoleAssignments, resourceGroupRoleAssignment)
 					}

--- a/cmd/list-resource-group-role-assignments.go
+++ b/cmd/list-resource-group-role-assignments.go
@@ -107,7 +107,7 @@ func listResourceGroupRoleAssignments(ctx context.Context, client client.AzureCl
 							ResourceGroupId: id,
 							RoleAssignment:  item.Ok,
 						}
-						log.V(2).Info("found resourceGroup role assignment", "id", resourceGroupRoleAssignment.RoleAssignment.Id, "name", resourceGroupRoleAssignment.RoleAssignment.Name, "resourceGroupId", resourceGroupRoleAssignment.ResourceGroupId)
+						log.V(2).Info("found resourceGroup role assignment", "name", resourceGroupRoleAssignment.RoleAssignment.Name)
 						count++
 						resourceGroupRoleAssignments.RoleAssignments = append(resourceGroupRoleAssignments.RoleAssignments, resourceGroupRoleAssignment)
 					}

--- a/cmd/list-resource-groups.go
+++ b/cmd/list-resource-groups.go
@@ -102,7 +102,7 @@ func listResourceGroups(ctx context.Context, client client.AzureClient, subscrip
 							SubscriptionId: "/subscriptions/" + id,
 							TenantId:       client.TenantInfo().TenantId,
 						}
-						log.V(2).Info("found resource group", "id", resourceGroup.Id, "name", resourceGroup.Name)
+						log.V(2).Info("found resource group", "name", resourceGroup.Name)
 						count++
 						if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
 							Kind: enums.KindAZResourceGroup,

--- a/cmd/list-resource-groups.go
+++ b/cmd/list-resource-groups.go
@@ -102,7 +102,7 @@ func listResourceGroups(ctx context.Context, client client.AzureClient, subscrip
 							SubscriptionId: "/subscriptions/" + id,
 							TenantId:       client.TenantInfo().TenantId,
 						}
-						log.V(2).Info("found resource group", "resourceGroup", resourceGroup)
+						log.V(2).Info("found resource group", "id", resourceGroup.Id, "name", resourceGroup.Name)
 						count++
 						if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
 							Kind: enums.KindAZResourceGroup,

--- a/cmd/list-role-assignment-policies.go
+++ b/cmd/list-role-assignment-policies.go
@@ -73,7 +73,7 @@ func listRoleAssignmentPolicies(ctx context.Context, azClient client.AzureClient
 
 				formattedItem.TenantId = azClient.TenantInfo().TenantId
 
-				log.V(2).Info("found unified role assignment policy", "unifiedRoleAssignmentPolicy", formattedItem)
+				log.V(2).Info("found unified role assignment policy", "policyId", formattedItem.UnifiedRoleManagementPolicyAssignment.Policy.Id)
 				count++
 
 				if ok := pipeline.SendAny(ctx.Done(), out, azureWrapper[models.RoleManagementPolicyAssignment]{

--- a/cmd/list-role-assignments.go
+++ b/cmd/list-role-assignments.go
@@ -106,7 +106,7 @@ func listRoleAssignments(ctx context.Context, client client.AzureClient, roles <
 					if item.Error != nil {
 						log.Error(item.Error, "unable to continue processing role assignments for this role", "roleDefinitionId", id)
 					} else {
-						log.V(2).Info("found role assignment", "roleAssignments", item)
+						log.V(2).Info("found role assignment", "id", item.Ok.Id, "name", item.Ok.RoleDefinition.DisplayName, "principalId", item.Ok.PrincipalId)
 						count++
 						// To ensure proper linking to AZApp nodes we want to supply the AppId instead when role assignments are app specific scoped
 						if item.Ok.DirectoryScopeId != "/" {

--- a/cmd/list-role-assignments.go
+++ b/cmd/list-role-assignments.go
@@ -106,7 +106,7 @@ func listRoleAssignments(ctx context.Context, client client.AzureClient, roles <
 					if item.Error != nil {
 						log.Error(item.Error, "unable to continue processing role assignments for this role", "roleDefinitionId", id)
 					} else {
-						log.V(2).Info("found role assignment", "id", item.Ok.Id, "name", item.Ok.RoleDefinition.DisplayName, "principalId", item.Ok.PrincipalId)
+						log.V(2).Info("found role assignment", "id", item.Ok.Id)
 						count++
 						// To ensure proper linking to AZApp nodes we want to supply the AppId instead when role assignments are app specific scoped
 						if item.Ok.DirectoryScopeId != "/" {

--- a/cmd/list-role-eligibility-schedule-instance.go
+++ b/cmd/list-role-eligibility-schedule-instance.go
@@ -72,7 +72,7 @@ func listRoleEligibilityScheduleInstances(ctx context.Context, client client.Azu
 				log.Error(item.Error, "unable to continue processing unified role eligibility instance schedules")
 				return
 			} else {
-				log.V(2).Info("found unified role eligibility instance schedule", "id", item.Ok.Id, "roleDefinitionId", item.Ok.RoleDefinitionId, "principalId", item.Ok.PrincipalId)
+				log.V(2).Info("found unified role eligibility instance schedule", "id", item.Ok.Id)
 				count++
 				result := item.Ok
 				if ok := pipeline.SendAny(ctx.Done(), out, azureWrapper[models.RoleEligibilityScheduleInstance]{

--- a/cmd/list-role-eligibility-schedule-instance.go
+++ b/cmd/list-role-eligibility-schedule-instance.go
@@ -19,6 +19,10 @@ package cmd
 
 import (
 	"context"
+	"os"
+	"os/signal"
+	"time"
+
 	"github.com/bloodhoundad/azurehound/v2/client"
 	"github.com/bloodhoundad/azurehound/v2/client/query"
 	"github.com/bloodhoundad/azurehound/v2/enums"
@@ -26,9 +30,6 @@ import (
 	"github.com/bloodhoundad/azurehound/v2/panicrecovery"
 	"github.com/bloodhoundad/azurehound/v2/pipeline"
 	"github.com/spf13/cobra"
-	"os"
-	"os/signal"
-	"time"
 )
 
 func init() {
@@ -71,7 +72,7 @@ func listRoleEligibilityScheduleInstances(ctx context.Context, client client.Azu
 				log.Error(item.Error, "unable to continue processing unified role eligibility instance schedules")
 				return
 			} else {
-				log.V(2).Info("found unified role eligibility instance schedule", "unifiedRoleEligibilitySchedule", item)
+				log.V(2).Info("found unified role eligibility instance schedule", "id", item.Ok.Id, "roleDefinitionId", item.Ok.RoleDefinitionId, "principalId", item.Ok.PrincipalId)
 				count++
 				result := item.Ok
 				if ok := pipeline.SendAny(ctx.Done(), out, azureWrapper[models.RoleEligibilityScheduleInstance]{

--- a/cmd/list-roles.go
+++ b/cmd/list-roles.go
@@ -70,7 +70,7 @@ func listRoles(ctx context.Context, client client.AzureClient) <-chan interface{
 				log.Error(item.Error, "unable to continue processing roles")
 				return
 			} else {
-				log.V(2).Info("found role", "role", item)
+				log.V(2).Info("found role", "id", item.Ok.Id, "displayName", item.Ok.DisplayName, "isEnabled", item.Ok.IsEnabled)
 				count++
 				if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
 					Kind: enums.KindAZRole,

--- a/cmd/list-roles.go
+++ b/cmd/list-roles.go
@@ -70,7 +70,7 @@ func listRoles(ctx context.Context, client client.AzureClient) <-chan interface{
 				log.Error(item.Error, "unable to continue processing roles")
 				return
 			} else {
-				log.V(2).Info("found role", "id", item.Ok.Id, "displayName", item.Ok.DisplayName, "isEnabled", item.Ok.IsEnabled)
+				log.V(2).Info("found role", "displayName", item.Ok.DisplayName)
 				count++
 				if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
 					Kind: enums.KindAZRole,

--- a/cmd/list-service-principal-owners.go
+++ b/cmd/list-service-principal-owners.go
@@ -106,7 +106,7 @@ func listServicePrincipalOwners(ctx context.Context, client client.AzureClient, 
 							Owner:              item.Ok,
 							ServicePrincipalId: id,
 						}
-						log.V(2).Info("found service principal owner", "servicePrincipalOwner", servicePrincipalOwner)
+						log.V(2).Info("found service principal owner", "servicePrincipalId", servicePrincipalOwner.ServicePrincipalId)
 						count++
 						servicePrincipalOwners.Owners = append(servicePrincipalOwners.Owners, servicePrincipalOwner)
 					}

--- a/cmd/list-service-principals.go
+++ b/cmd/list-service-principals.go
@@ -70,7 +70,7 @@ func listServicePrincipals(ctx context.Context, client client.AzureClient) <-cha
 				log.Error(item.Error, "unable to continue processing service principals")
 				return
 			} else {
-				log.V(2).Info("found service principal", "id", item.Ok.Id, "name", item.Ok.DisplayName, "appId", item.Ok.AppId)
+				log.V(2).Info("found service principal", "name", item.Ok.DisplayName)
 				count++
 				if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
 					Kind: enums.KindAZServicePrincipal,

--- a/cmd/list-service-principals.go
+++ b/cmd/list-service-principals.go
@@ -70,7 +70,7 @@ func listServicePrincipals(ctx context.Context, client client.AzureClient) <-cha
 				log.Error(item.Error, "unable to continue processing service principals")
 				return
 			} else {
-				log.V(2).Info("found service principal", "servicePrincipal", item)
+				log.V(2).Info("found service principal", "id", item.Ok.Id, "name", item.Ok.DisplayName, "appId", item.Ok.AppId)
 				count++
 				if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
 					Kind: enums.KindAZServicePrincipal,

--- a/cmd/list-storage-account-role-assignments.go
+++ b/cmd/list-storage-account-role-assignments.go
@@ -110,7 +110,7 @@ func listStorageAccountRoleAssignments(ctx context.Context, client client.AzureC
 							ObjectId:         id,
 							RoleDefinitionId: roleDefinitionId,
 						}
-						log.V(2).Info("found storage account role assignment", "storageAccountRoleAssignment", storageAccountRoleAssignment)
+						log.V(2).Info("found storage account role assignment", "id", storageAccountRoleAssignment.ObjectId, "roleDefinitionId", storageAccountRoleAssignment.RoleDefinitionId, "principalId", storageAccountRoleAssignment.Assignee.GetPrincipalId())
 						count++
 						storageAccountRoleAssignments.RoleAssignments = append(storageAccountRoleAssignments.RoleAssignments, storageAccountRoleAssignment)
 					}

--- a/cmd/list-storage-account-role-assignments.go
+++ b/cmd/list-storage-account-role-assignments.go
@@ -110,7 +110,7 @@ func listStorageAccountRoleAssignments(ctx context.Context, client client.AzureC
 							ObjectId:         id,
 							RoleDefinitionId: roleDefinitionId,
 						}
-						log.V(2).Info("found storage account role assignment", "id", storageAccountRoleAssignment.ObjectId, "roleDefinitionId", storageAccountRoleAssignment.RoleDefinitionId, "principalId", storageAccountRoleAssignment.Assignee.GetPrincipalId())
+						log.V(2).Info("found storage account role assignment", "roleDefinitionId", storageAccountRoleAssignment.RoleDefinitionId)
 						count++
 						storageAccountRoleAssignments.RoleAssignments = append(storageAccountRoleAssignments.RoleAssignments, storageAccountRoleAssignment)
 					}

--- a/cmd/list-storage-accounts.go
+++ b/cmd/list-storage-accounts.go
@@ -102,7 +102,7 @@ func listStorageAccounts(ctx context.Context, client client.AzureClient, subscri
 							ResourceGroupName: item.Ok.ResourceGroupName(),
 							TenantId:          client.TenantInfo().TenantId,
 						}
-						log.V(2).Info("found storage account", "id", storageAccount.StorageAccount.Id, "name", storageAccount.Name)
+						log.V(2).Info("found storage account", "name", storageAccount.Name)
 						count++
 						if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
 							Kind: enums.KindAZStorageAccount,

--- a/cmd/list-storage-accounts.go
+++ b/cmd/list-storage-accounts.go
@@ -102,7 +102,7 @@ func listStorageAccounts(ctx context.Context, client client.AzureClient, subscri
 							ResourceGroupName: item.Ok.ResourceGroupName(),
 							TenantId:          client.TenantInfo().TenantId,
 						}
-						log.V(2).Info("found storage account", "storageAccount", storageAccount)
+						log.V(2).Info("found storage account", "id", storageAccount.StorageAccount.Id, "name", storageAccount.Name)
 						count++
 						if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
 							Kind: enums.KindAZStorageAccount,

--- a/cmd/list-storage-containers.go
+++ b/cmd/list-storage-containers.go
@@ -110,7 +110,7 @@ func listStorageContainers(ctx context.Context, client client.AzureClient, stora
 							ResourceGroupName: item.Ok.ResourceGroupName(),
 							TenantId:          client.TenantInfo().TenantId,
 						}
-						log.V(2).Info("found storage container", "id", storageContainer.Id, "name", storageContainer.Name, "tenant", storageContainer.TenantId)
+						log.V(2).Info("found storage container", "name", storageContainer.Name)
 						count++
 						if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
 							Kind: enums.KindAZStorageContainer,

--- a/cmd/list-storage-containers.go
+++ b/cmd/list-storage-containers.go
@@ -110,7 +110,7 @@ func listStorageContainers(ctx context.Context, client client.AzureClient, stora
 							ResourceGroupName: item.Ok.ResourceGroupName(),
 							TenantId:          client.TenantInfo().TenantId,
 						}
-						log.V(2).Info("found storage container", "storageContainer", storageContainer)
+						log.V(2).Info("found storage container", "id", storageContainer.Id, "name", storageContainer.Name, "tenant", storageContainer.TenantId)
 						count++
 						if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
 							Kind: enums.KindAZStorageContainer,

--- a/cmd/list-subscription-owners.go
+++ b/cmd/list-subscription-owners.go
@@ -88,7 +88,7 @@ func listSubscriptionOwners(ctx context.Context, client client.AzureClient, role
 							Owner:          item.RoleAssignment,
 							SubscriptionId: item.SubscriptionId,
 						}
-						log.V(2).Info("found subscription owner", "principalId", subscriptionOwner.Owner.GetPrincipalId(), "role", subscriptionOwner.Owner.Name, "subscriptionId", subscriptionOwner.SubscriptionId)
+						log.V(2).Info("found subscription owner", "name", subscriptionOwner.Owner.Name)
 						count++
 						subscriptionOwners.Owners = append(subscriptionOwners.Owners, subscriptionOwner)
 					}

--- a/cmd/list-subscription-owners.go
+++ b/cmd/list-subscription-owners.go
@@ -88,7 +88,7 @@ func listSubscriptionOwners(ctx context.Context, client client.AzureClient, role
 							Owner:          item.RoleAssignment,
 							SubscriptionId: item.SubscriptionId,
 						}
-						log.V(2).Info("found subscription owner", "subscriptionOwner", subscriptionOwner)
+						log.V(2).Info("found subscription owner", "principalId", subscriptionOwner.Owner.GetPrincipalId(), "role", subscriptionOwner.Owner.Name, "subscriptionId", subscriptionOwner.SubscriptionId)
 						count++
 						subscriptionOwners.Owners = append(subscriptionOwners.Owners, subscriptionOwner)
 					}

--- a/cmd/list-subscription-role-assignments.go
+++ b/cmd/list-subscription-role-assignments.go
@@ -106,7 +106,7 @@ func listSubscriptionRoleAssignments(ctx context.Context, client client.AzureCli
 							SubscriptionId: id,
 							RoleAssignment: item.Ok,
 						}
-						log.V(2).Info("found subscription role assignment", "subscriptionRoleAssignment", subscriptionRoleAssignment)
+						log.V(2).Info("found subscription role assignment", "id", subscriptionRoleAssignment.RoleAssignment.Id, "name", subscriptionRoleAssignment.RoleAssignment.Name)
 						count++
 						subscriptionRoleAssignments.RoleAssignments = append(subscriptionRoleAssignments.RoleAssignments, subscriptionRoleAssignment)
 					}

--- a/cmd/list-subscription-role-assignments.go
+++ b/cmd/list-subscription-role-assignments.go
@@ -106,7 +106,7 @@ func listSubscriptionRoleAssignments(ctx context.Context, client client.AzureCli
 							SubscriptionId: id,
 							RoleAssignment: item.Ok,
 						}
-						log.V(2).Info("found subscription role assignment", "id", subscriptionRoleAssignment.RoleAssignment.Id, "name", subscriptionRoleAssignment.RoleAssignment.Name)
+						log.V(2).Info("found subscription role assignment", "name", subscriptionRoleAssignment.RoleAssignment.Name)
 						count++
 						subscriptionRoleAssignments.RoleAssignments = append(subscriptionRoleAssignments.RoleAssignments, subscriptionRoleAssignment)
 					}

--- a/cmd/list-subscription-user-access-admins.go
+++ b/cmd/list-subscription-user-access-admins.go
@@ -88,7 +88,7 @@ func listSubscriptionUserAccessAdmins(ctx context.Context, client client.AzureCl
 							UserAccessAdmin: item.RoleAssignment,
 							SubscriptionId:  item.SubscriptionId,
 						}
-						log.V(2).Info("found subscription user access admin", "id", subscriptionUserAccessAdmin.UserAccessAdmin.Id, "principalId", subscriptionUserAccessAdmin.UserAccessAdmin.Properties.PrincipalId, "scope", subscriptionUserAccessAdmin.UserAccessAdmin.Properties.Scope, "roleId", subscriptionUserAccessAdmin.UserAccessAdmin.Properties.RoleDefinitionId)
+						log.V(2).Info("found subscription user access admin", "name", subscriptionUserAccessAdmin.UserAccessAdmin.Name)
 						count++
 						subscriptionUserAccessAdmins.UserAccessAdmins = append(subscriptionUserAccessAdmins.UserAccessAdmins, subscriptionUserAccessAdmin)
 					}

--- a/cmd/list-subscription-user-access-admins.go
+++ b/cmd/list-subscription-user-access-admins.go
@@ -88,7 +88,7 @@ func listSubscriptionUserAccessAdmins(ctx context.Context, client client.AzureCl
 							UserAccessAdmin: item.RoleAssignment,
 							SubscriptionId:  item.SubscriptionId,
 						}
-						log.V(2).Info("found subscription user access admin", "subscriptionUserAccessAdmin", subscriptionUserAccessAdmin)
+						log.V(2).Info("found subscription user access admin", "id", subscriptionUserAccessAdmin.UserAccessAdmin.Id, "principalId", subscriptionUserAccessAdmin.UserAccessAdmin.Properties.PrincipalId, "scope", subscriptionUserAccessAdmin.UserAccessAdmin.Properties.Scope, "roleId", subscriptionUserAccessAdmin.UserAccessAdmin.Properties.RoleDefinitionId)
 						count++
 						subscriptionUserAccessAdmins.UserAccessAdmins = append(subscriptionUserAccessAdmins.UserAccessAdmins, subscriptionUserAccessAdmin)
 					}

--- a/cmd/list-subscriptions.go
+++ b/cmd/list-subscriptions.go
@@ -92,7 +92,7 @@ func listSubscriptions(ctx context.Context, client client.AzureClient) <-chan in
 				log.Error(item.Error, "unable to continue processing subscriptions")
 				return
 			} else if !filterOnSubs || contains(uniqueSubIds, item.Ok.SubscriptionId) {
-				log.V(2).Info("found subscription", "subscription.Id", item.Ok.SubscriptionId)
+				log.V(2).Info("found subscription", "name", item.Ok.DisplayName)
 				count++
 				// the embedded struct's values override top-level properties so TenantId
 				// needs to be explicitly set.

--- a/cmd/list-subscriptions.go
+++ b/cmd/list-subscriptions.go
@@ -92,7 +92,7 @@ func listSubscriptions(ctx context.Context, client client.AzureClient) <-chan in
 				log.Error(item.Error, "unable to continue processing subscriptions")
 				return
 			} else if !filterOnSubs || contains(uniqueSubIds, item.Ok.SubscriptionId) {
-				log.V(2).Info("found subscription", "subscription", item)
+				log.V(2).Info("found subscription", "subscription.Id", item.Ok.SubscriptionId)
 				count++
 				// the embedded struct's values override top-level properties so TenantId
 				// needs to be explicitly set.

--- a/cmd/list-tenants.go
+++ b/cmd/list-tenants.go
@@ -81,7 +81,7 @@ func listTenants(ctx context.Context, client client.AzureClient) <-chan interfac
 				log.Error(item.Error, "unable to continue processing tenants")
 				return
 			} else {
-				log.V(2).Info("found tenant", "tenant", item)
+				log.V(2).Info("found tenant", "id", item.Ok.Id, "name", item.Ok.DisplayName, "tenantId", item.Ok.TenantId)
 				count++
 
 				// Send the remaining tenant trusts

--- a/cmd/list-tenants.go
+++ b/cmd/list-tenants.go
@@ -81,7 +81,7 @@ func listTenants(ctx context.Context, client client.AzureClient) <-chan interfac
 				log.Error(item.Error, "unable to continue processing tenants")
 				return
 			} else {
-				log.V(2).Info("found tenant", "id", item.Ok.Id, "name", item.Ok.DisplayName, "tenantId", item.Ok.TenantId)
+				log.V(2).Info("found tenant", "id", item.Ok.TenantId)
 				count++
 
 				// Send the remaining tenant trusts

--- a/cmd/list-users.go
+++ b/cmd/list-users.go
@@ -84,7 +84,7 @@ func listUsers(ctx context.Context, client client.AzureClient) <-chan interface{
 				log.Error(item.Error, "unable to continue processing users")
 				return
 			} else {
-				log.V(2).Info("found user", "user", item)
+				log.V(2).Info("found user", "id", item.Ok.Id, "type", item.Ok.Type, "isEnabled", item.Ok.AccountEnabled)
 				count++
 				user := models.User{
 					User:       item.Ok,

--- a/cmd/list-users.go
+++ b/cmd/list-users.go
@@ -84,7 +84,7 @@ func listUsers(ctx context.Context, client client.AzureClient) <-chan interface{
 				log.Error(item.Error, "unable to continue processing users")
 				return
 			} else {
-				log.V(2).Info("found user", "id", item.Ok.Id, "type", item.Ok.Type, "isEnabled", item.Ok.AccountEnabled)
+				log.V(2).Info("found user", "id", item.Ok.Id)
 				count++
 				user := models.User{
 					User:       item.Ok,

--- a/cmd/list-virtual-machine-role-assignments.go
+++ b/cmd/list-virtual-machine-role-assignments.go
@@ -106,7 +106,7 @@ func listVirtualMachineRoleAssignments(ctx context.Context, client client.AzureC
 							VirtualMachineId: id,
 							RoleAssignment:   item.Ok,
 						}
-						log.V(2).Info("found virtual machine role assignment", "roleId", virtualMachineRoleAssignment.RoleAssignment.Id, "virtualMachineId", virtualMachineRoleAssignment.VirtualMachineId)
+						log.V(2).Info("found virtual machine role assignment", "name", virtualMachineRoleAssignment.RoleAssignment.Name)
 						count++
 						virtualMachineRoleAssignments.RoleAssignments = append(virtualMachineRoleAssignments.RoleAssignments, virtualMachineRoleAssignment)
 					}

--- a/cmd/list-virtual-machine-role-assignments.go
+++ b/cmd/list-virtual-machine-role-assignments.go
@@ -106,7 +106,7 @@ func listVirtualMachineRoleAssignments(ctx context.Context, client client.AzureC
 							VirtualMachineId: id,
 							RoleAssignment:   item.Ok,
 						}
-						log.V(2).Info("found virtual machine role assignment", "virtualMachineRoleAssignment", virtualMachineRoleAssignment)
+						log.V(2).Info("found virtual machine role assignment", "roleId", virtualMachineRoleAssignment.RoleAssignment.Id, "virtualMachineId", virtualMachineRoleAssignment.VirtualMachineId)
 						count++
 						virtualMachineRoleAssignments.RoleAssignments = append(virtualMachineRoleAssignments.RoleAssignments, virtualMachineRoleAssignment)
 					}

--- a/cmd/list-virtual-machines.go
+++ b/cmd/list-virtual-machines.go
@@ -102,7 +102,7 @@ func listVirtualMachines(ctx context.Context, client client.AzureClient, subscri
 							ResourceGroupId: item.Ok.ResourceGroupId(),
 							TenantId:        client.TenantInfo().TenantId,
 						}
-						log.V(2).Info("found virtual machine", "virtualMachine", virtualMachine)
+						log.V(2).Info("found virtual machine", "id", virtualMachine.Id, "name", virtualMachine.Name, "tenantId", virtualMachine.TenantId)
 						count++
 						if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
 							Kind: enums.KindAZVM,

--- a/cmd/list-virtual-machines.go
+++ b/cmd/list-virtual-machines.go
@@ -102,7 +102,7 @@ func listVirtualMachines(ctx context.Context, client client.AzureClient, subscri
 							ResourceGroupId: item.Ok.ResourceGroupId(),
 							TenantId:        client.TenantInfo().TenantId,
 						}
-						log.V(2).Info("found virtual machine", "id", virtualMachine.Id, "name", virtualMachine.Name, "tenantId", virtualMachine.TenantId)
+						log.V(2).Info("found virtual machine", "name", virtualMachine.Name)
 						count++
 						if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
 							Kind: enums.KindAZVM,

--- a/cmd/list-vm-scale-set-role-assignments.go
+++ b/cmd/list-vm-scale-set-role-assignments.go
@@ -115,7 +115,7 @@ func listVMScaleSetRoleAssignments(ctx context.Context, client client.AzureClien
 							ObjectId:         id,
 							RoleDefinitionId: roleDefinitionId,
 						}
-						log.V(2).Info("found vm scale set role assignment", "vmScaleSetRoleAssignment", vmScaleSetRoleAssignment)
+						log.V(2).Info("found vm scale set role assignment", "id", vmScaleSetRoleAssignment.ObjectId, "roleId", vmScaleSetRoleAssignment.RoleDefinitionId)
 						count++
 						vmScaleSetRoleAssignments.RoleAssignments = append(vmScaleSetRoleAssignments.RoleAssignments, vmScaleSetRoleAssignment)
 					}

--- a/cmd/list-vm-scale-set-role-assignments.go
+++ b/cmd/list-vm-scale-set-role-assignments.go
@@ -115,7 +115,7 @@ func listVMScaleSetRoleAssignments(ctx context.Context, client client.AzureClien
 							ObjectId:         id,
 							RoleDefinitionId: roleDefinitionId,
 						}
-						log.V(2).Info("found vm scale set role assignment", "id", vmScaleSetRoleAssignment.ObjectId, "roleId", vmScaleSetRoleAssignment.RoleDefinitionId)
+						log.V(2).Info("found vm scale set role assignment", "roleId", vmScaleSetRoleAssignment.RoleDefinitionId)
 						count++
 						vmScaleSetRoleAssignments.RoleAssignments = append(vmScaleSetRoleAssignments.RoleAssignments, vmScaleSetRoleAssignment)
 					}

--- a/cmd/list-vm-scale-sets.go
+++ b/cmd/list-vm-scale-sets.go
@@ -107,7 +107,7 @@ func listVMScaleSets(ctx context.Context, client client.AzureClient, subscriptio
 							ResourceGroupId: item.Ok.ResourceGroupId(),
 							TenantId:        client.TenantInfo().TenantId,
 						}
-						log.V(2).Info("found virtual machine scale set", "id", vmScaleSet.Id, "name", vmScaleSet.Name)
+						log.V(2).Info("found virtual machine scale set", "name", vmScaleSet.Name)
 						count++
 						if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
 							Kind: enums.KindAZVMScaleSet,

--- a/cmd/list-vm-scale-sets.go
+++ b/cmd/list-vm-scale-sets.go
@@ -107,7 +107,7 @@ func listVMScaleSets(ctx context.Context, client client.AzureClient, subscriptio
 							ResourceGroupId: item.Ok.ResourceGroupId(),
 							TenantId:        client.TenantInfo().TenantId,
 						}
-						log.V(2).Info("found virtual machine scale set", "vmScaleSet", vmScaleSet)
+						log.V(2).Info("found virtual machine scale set", "id", vmScaleSet.Id, "name", vmScaleSet.Name)
 						count++
 						if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
 							Kind: enums.KindAZVMScaleSet,

--- a/cmd/list-web-app-role-assignments.go
+++ b/cmd/list-web-app-role-assignments.go
@@ -115,7 +115,7 @@ func listWebAppRoleAssignments(ctx context.Context, client client.AzureClient, w
 							ObjectId:         id,
 							RoleDefinitionId: roleDefinitionId,
 						}
-						log.V(2).Info("Found web app role asignment", "webAppRoleAssignment", webAppRoleAssignment)
+						log.V(2).Info("Found web app role assignment", "roleDefinitionId", webAppRoleAssignment.RoleDefinitionId)
 						count++
 						webAppRoleAssignments.RoleAssignments = append(webAppRoleAssignments.RoleAssignments, webAppRoleAssignment)
 					}

--- a/cmd/list-web-apps.go
+++ b/cmd/list-web-apps.go
@@ -108,7 +108,7 @@ func listWebApps(ctx context.Context, client client.AzureClient, subscriptions <
 							TenantId:          client.TenantInfo().TenantId,
 						}
 						if webApp.Kind == "app" {
-							log.V(2).Info("found web app", "id", webApp.Id, "name", webApp.Name)
+							log.V(2).Info("found web app", "name", webApp.Name)
 							count++
 							if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
 								Kind: enums.KindAZWebApp,

--- a/cmd/list-web-apps.go
+++ b/cmd/list-web-apps.go
@@ -108,7 +108,7 @@ func listWebApps(ctx context.Context, client client.AzureClient, subscriptions <
 							TenantId:          client.TenantInfo().TenantId,
 						}
 						if webApp.Kind == "app" {
-							log.V(2).Info("found web app", "webApp", webApp)
+							log.V(2).Info("found web app", "id", webApp.Id, "name", webApp.Name)
 							count++
 							if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
 								Kind: enums.KindAZWebApp,


### PR DESCRIPTION
Currently, when verbose logs are enabled, the output is extremely bloated, caused by log statements printing entire objects when they are found. In this MR, each action performed by the app has has its verbose log statement modified to only include a couple of key details (`id`, `name`) rather than the entire object. Since the application will generate an output file containing all the info that would be in the trace logs, there is no need for duplicating all the details. 

> [!NOTE]
> **Demo:**
> Trace log file size comparison after changes:
> <img width="441" height="46" alt="image" src="https://github.com/user-attachments/assets/770de133-ebb5-4b61-a6a6-173eba573e0f" />
> -> Log file output reduced by ~6x

To test: run AzureHound with Verbose logs enabled and compare the new log output to the previous log output - the new one should be significantly smaller in size. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved diagnostic logging to emit narrower, more focused fields for many resource listings (less noisy structured logs).
  * Corrected several logging message typos for clearer output.
  * Updated JetBrains ignore rules to exclude IDE metadata files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->