### PR TITLE
fix: remove unneeded channel for devices - BED-7366

### DIFF
--- a/cmd/list-azure-ad.go
+++ b/cmd/list-azure-ad.go
@@ -84,7 +84,7 @@ func listAllAD(ctx context.Context, client client.AzureClient) <-chan interface{
 	apps := pipeline.ToAny(ctx.Done(), appChans[0])
 	appOwners := pipeline.ToAny(ctx.Done(), listAppOwners(ctx, client, appChans[1]))
 
-	// Enumerate Devices and DeviceOwners
+	// Enumerate Devices
 	pipeline.Tee(ctx.Done(), listDevices(ctx, client), devices)
 
 	// Enumerate Groups, GroupOwners and GroupMembers

--- a/cmd/list-azure-ad.go
+++ b/cmd/list-azure-ad.go
@@ -63,8 +63,7 @@ func listAzureADCmdImpl(cmd *cobra.Command, args []string) {
 
 func listAllAD(ctx context.Context, client client.AzureClient) <-chan interface{} {
 	var (
-		devices  = make(chan interface{})
-		devices2 = make(chan interface{})
+		devices = make(chan interface{})
 
 		groups  = make(chan interface{})
 		groups2 = make(chan interface{})
@@ -86,7 +85,7 @@ func listAllAD(ctx context.Context, client client.AzureClient) <-chan interface{
 	appOwners := pipeline.ToAny(ctx.Done(), listAppOwners(ctx, client, appChans[1]))
 
 	// Enumerate Devices and DeviceOwners
-	pipeline.Tee(ctx.Done(), listDevices(ctx, client), devices, devices2)
+	pipeline.Tee(ctx.Done(), listDevices(ctx, client), devices)
 
 	// Enumerate Groups, GroupOwners and GroupMembers
 	pipeline.Tee(ctx.Done(), listGroups(ctx, client), groups, groups2, groups3)


### PR DESCRIPTION
This fix removes an unneeded channel that was causing AzureHound to hang on collection. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified internal device processing pipeline to reduce resource usage and concurrency, improving efficiency and stability with no change to user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->