### PR TITLE
fix: remove custom unmarshaller to fix unmarshalling of wrapper struct

### DIFF
--- a/cmd/list-users.go
+++ b/cmd/list-users.go
@@ -99,6 +99,7 @@ func listUsers(ctx context.Context, client client.AzureClient) <-chan interface{
 					TenantId:   client.TenantInfo().TenantId,
 					TenantName: client.TenantInfo().DisplayName,
 				}
+
 				if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
 					Kind: enums.KindAZUser,
 					Data: user,
@@ -109,12 +110,10 @@ func listUsers(ctx context.Context, client client.AzureClient) <-chan interface{
 			return count, nil
 		}
 
-		includeSignInActivity := true
 		params := makeParams(true)
 		count, err := streamOnce(params)
-		if err != nil && includeSignInActivity && count == 0 && isGraphAuthorizationDenied(err) {
+		if err != nil && count == 0 && isGraphAuthorizationDenied(err) {
 			log.Info("warning: authorization denied when requesting signInActivity for users (missing AuditLog.Read.All API permission); retrying without signInActivity")
-			includeSignInActivity = false
 			params = makeParams(false)
 			count, err = streamOnce(params)
 		}

--- a/models/azure/user-signinactivity.go
+++ b/models/azure/user-signinactivity.go
@@ -2,10 +2,10 @@ package azure
 
 // SignInActivity represents Microsoft Graph's `signInActivity` object returned on the user entity.
 type SignInActivity struct {
-	LastSignInDateTime                string `json:"lastSignInDateTime,omitempty"`
-	LastSignInRequestId               string `json:"lastSignInRequestId,omitempty"`
-	LastNonInteractiveSignInDateTime  string `json:"lastNonInteractiveSignInDateTime,omitempty"`
-	LastNonInteractiveSignInRequestId string `json:"lastNonInteractiveSignInRequestId,omitempty"`
-	LastSuccessfulSignInDateTime      string `json:"lastSuccessfulSignInDateTime,omitempty"`
-	LastSuccessfulSignInRequestId     string `json:"lastSuccessfulSignInRequestId,omitempty"`
+	LastSignInDateTime                *string `json:"lastSignInDateTime,omitempty"`
+	LastSignInRequestId               *string `json:"lastSignInRequestId,omitempty"`
+	LastNonInteractiveSignInDateTime  *string `json:"lastNonInteractiveSignInDateTime,omitempty"`
+	LastNonInteractiveSignInRequestId *string `json:"lastNonInteractiveSignInRequestId,omitempty"`
+	LastSuccessfulSignInDateTime      *string `json:"lastSuccessfulSignInDateTime,omitempty"`
+	LastSuccessfulSignInRequestId     *string `json:"lastSuccessfulSignInRequestId,omitempty"`
 }

--- a/models/azure/user-signinactivity.go
+++ b/models/azure/user-signinactivity.go
@@ -1,34 +1,11 @@
 package azure
 
-import "encoding/json"
-
-type userAlias User
-
-type userUnmarshalJSON struct {
-	*userAlias
-	SignInActivity *SignInActivity `json:"signInActivity,omitempty"`
-}
-
-func (s *User) UnmarshalJSON(data []byte) error {
-	aux := userUnmarshalJSON{userAlias: (*userAlias)(s)}
-
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-
-	if s.LastSuccessfulSignInDateTime == "" && aux.SignInActivity != nil && aux.SignInActivity.LastSuccessfulSignInDateTime != nil {
-		s.LastSuccessfulSignInDateTime = *aux.SignInActivity.LastSuccessfulSignInDateTime
-	}
-
-	return nil
-}
-
 // SignInActivity represents Microsoft Graph's `signInActivity` object returned on the user entity.
 type SignInActivity struct {
-	LastSignInDateTime                *string `json:"lastSignInDateTime,omitempty"`
-	LastSignInRequestId               *string `json:"lastSignInRequestId,omitempty"`
-	LastNonInteractiveSignInDateTime  *string `json:"lastNonInteractiveSignInDateTime,omitempty"`
-	LastNonInteractiveSignInRequestId *string `json:"lastNonInteractiveSignInRequestId,omitempty"`
-	LastSuccessfulSignInDateTime      *string `json:"lastSuccessfulSignInDateTime,omitempty"`
-	LastSuccessfulSignInRequestId     *string `json:"lastSuccessfulSignInRequestId,omitempty"`
+	LastSignInDateTime                string `json:"lastSignInDateTime,omitempty"`
+	LastSignInRequestId               string `json:"lastSignInRequestId,omitempty"`
+	LastNonInteractiveSignInDateTime  string `json:"lastNonInteractiveSignInDateTime,omitempty"`
+	LastNonInteractiveSignInRequestId string `json:"lastNonInteractiveSignInRequestId,omitempty"`
+	LastSuccessfulSignInDateTime      string `json:"lastSuccessfulSignInDateTime,omitempty"`
+	LastSuccessfulSignInRequestId     string `json:"lastSuccessfulSignInRequestId,omitempty"`
 }

--- a/models/azure/user.go
+++ b/models/azure/user.go
@@ -430,6 +430,9 @@ type User struct {
 	// Returned only on $select.
 	SignInSessionsValidFromDateTime string `json:"signInSessionsValidFromDateTime,omitempty"`
 
+	// The signin activity for the User
+	SignInActivity SignInActivity `json:"signInActivity,omitempty"`
+
 	// The state or province in the user's address.
 	// Maximum length is 128 characters.
 	// Returned only on $select.

--- a/models/azure/user.go
+++ b/models/azure/user.go
@@ -215,12 +215,6 @@ type User struct {
 	// Returned only on `$select`
 	LastPasswordChangeDateTime string `json:"lastPasswordChangeDateTime,omitempty"`
 
-	// The last time the user successfully signed in, in ISO 8601 format (UTC time).
-	//
-	// This value is sourced from the Microsoft Graph `signInActivity` dictionary.
-	// To populate it, the client must include `signInActivity` in `$select`.
-	LastSuccessfulSignInDateTime string `json:"lastSuccessfulSignInDateTime,omitempty"`
-
 	// Used by enterprise applications to determine the legal age group of the user.
 	//
 	// Returned only on `$select`

--- a/models/azure/user_test.go
+++ b/models/azure/user_test.go
@@ -41,7 +41,7 @@ func TestUserUnmarshal_PopulatesLastSuccessfulSignInDateTimeFromSignInActivity(t
 		t.Fatalf("unexpected unmarshal error: %v", err)
 	}
 
-	if u.LastSuccessfulSignInDateTime != "2025-01-27T22:20:22Z" {
-		t.Fatalf("expected LastSuccessfulSignInDateTime to be populated, got %q", u.LastSuccessfulSignInDateTime)
+	if *u.SignInActivity.LastSuccessfulSignInDateTime != "2025-01-27T22:20:22Z" {
+		t.Fatalf("expected LastSuccessfulSignInDateTime to be populated, got %q", *u.SignInActivity.LastSuccessfulSignInDateTime)
 	}
 }


### PR DESCRIPTION
https://specterops.atlassian.net/browse/BED-7396

The custom UnmarshalJSON function on the user struct breaks unmarshalling of the TenantName/TenantID fields on the outer struct that embeds this one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in activity retrieval: if permission errors prevent detailed data and no results streamed, the system now automatically retries in a safe mode so users still see available results.

* **Refactor**
  * Simplified sign-in activity representation and parsing for more consistent, reliable display of user sign-in information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->