### PR TITLE
fix: remove pull request target from cla - BED-7555

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -2,7 +2,7 @@ name: "CLA Assistant"
 on:
   issue_comment:
     types: [created, edited]
-  pull_request_target:
+  pull_request:
     types: [opened,closed,synchronize]
 
 jobs:
@@ -33,7 +33,7 @@ jobs:
           echo "org_members=$ALL_MEMBERS" >> $GITHUB_OUTPUT
         
       - name: "CLA Assistant"
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request'
         uses: contributor-assistant/github-action@v2.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Remove pull_request_target from cla.

Resolves BED-7555

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the contributor license agreement workflow configuration to use an alternative event trigger type for improved handling of pull request validations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->