### PR TITLE
BED-7634: Azurehound - Fix `listResourceGroupUserAccessAdmins` filtering by wrong role ID

### DIFF
--- a/cmd/list-resource-group-user-access-admins.go
+++ b/cmd/list-resource-group-user-access-admins.go
@@ -66,7 +66,7 @@ func listResourceGroupUserAccessAdmins(
 	roleAssignments <-chan azureWrapper[models.ResourceGroupRoleAssignments],
 ) <-chan any {
 	return pipeline.Map(ctx.Done(), roleAssignments, func(ra azureWrapper[models.ResourceGroupRoleAssignments]) any {
-		filteredAssignments := internal.Filter(ra.Data.RoleAssignments, rgRoleAssignmentFilter(constants.OwnerRoleID))
+		filteredAssignments := internal.Filter(ra.Data.RoleAssignments, rgRoleAssignmentFilter(constants.UserAccessAdminRoleID))
 		uaas := internal.Map(filteredAssignments, func(ra models.ResourceGroupRoleAssignment) models.ResourceGroupUserAccessAdmin {
 			return models.ResourceGroupUserAccessAdmin{
 				UserAccessAdmin: ra.RoleAssignment,

--- a/cmd/list-resource-group-user-access-admins_test.go
+++ b/cmd/list-resource-group-user-access-admins_test.go
@@ -55,9 +55,17 @@ func TestListResourceGroupUserAccessAdmins(t *testing.T) {
 				RoleAssignments: []models.ResourceGroupRoleAssignment{
 					{
 						RoleAssignment: azure.RoleAssignment{
-							Name: constants.UserAccessAdminRoleID,
+							Name: "uaa-assignment",
 							Properties: azure.RoleAssignmentPropertiesWithScope{
 								RoleDefinitionId: constants.UserAccessAdminRoleID,
+							},
+						},
+					},
+					{
+						RoleAssignment: azure.RoleAssignment{
+							Name: "owner-assignment",
+							Properties: azure.RoleAssignmentPropertiesWithScope{
+								RoleDefinitionId: constants.OwnerRoleID,
 							},
 						},
 					},
@@ -66,11 +74,29 @@ func TestListResourceGroupUserAccessAdmins(t *testing.T) {
 		)
 	}()
 
-	if _, ok := <-channel; !ok {
+	result, ok := <-channel
+	if !ok {
 		t.Fatalf("failed to receive from channel")
 	}
 
+	wrapper, ok := result.(azureWrapper[models.ResourceGroupUserAccessAdmins])
+	if !ok {
+		t.Fatalf("unexpected type in channel: %T", result)
+	}
+
+	if wrapper.Data.ResourceGroupId != "foo" {
+		t.Errorf("expected ResourceGroupId 'foo', got '%s'", wrapper.Data.ResourceGroupId)
+	}
+
+	if len(wrapper.Data.UserAccessAdmins) != 1 {
+		t.Fatalf("expected 1 user access admin, got %d", len(wrapper.Data.UserAccessAdmins))
+	}
+
+	if wrapper.Data.UserAccessAdmins[0].UserAccessAdmin.Name != "uaa-assignment" {
+		t.Errorf("expected user access admin name 'uaa-assignment', got '%s'", wrapper.Data.UserAccessAdmins[0].UserAccessAdmin.Name)
+	}
+
 	if _, ok := <-channel; ok {
-		t.Error("should not have recieved from channel")
+		t.Error("should not have received from channel")
 	}
 }


### PR DESCRIPTION
## Ticket: 
[BED-7634](https://specterops.atlassian.net/browse/BED-7634)

## Summary: 
Fixes the role ID filter in listResourceGroupUserAccessAdmins() — it was using constants.OwnerRoleID instead of constants.UserAccessAdminRoleID, causing Resource Group User Access Admin edges in BloodHound to reflect Owner relationships.

As a result of this, I made [another ticket](https://specterops.atlassian.net/browse/BED-7664) to go and update all the other tests that follow this same pattern since most of them have the same flaw.

## Changes:
`cmd/list-resource-group-user-access-admins.go`
-  Changed filter from OwnerRoleID to UserAccessAdminRoleID to match name of function

`cmd/list-resource-group-user-access-admins_test.go`
-  Rewrote test to send both a matching and non-matching role assignment and assert on the output data, not just channel activity

Resolves [BED-7634](https://specterops.atlassian.net/browse/BED-7634)

## Customer Impact
The incorrectly filtered nodes will remain incorrect for up to 7 days in customer envs without adding an additional DB migration. BHE runs auto-pruning operations and deletes all relationship edges whose `lastSeen` timestamp is older than BaseTTL (which is 7 days) so when these old (incorrect) edges are left in the env for 7 days and get replaced by the new (valid) nodes, the old ones will be cleaned up. No migration needed.

## Testing Notes
Refer to the [ticket](https://specterops.atlassian.net/browse/BED-7634)

## Demo
- Before this change, querying `ResourceGroupUserAccessAdmins` and `ResourceGroupOwners` would yield the same results, which was incorrect. 
- After running a fresh AzureHound collection with the new changes, importing the output into BHE (local) now provides accurate Resource Group User Access Admin edges:

### Before: 
- Cypher query for `UAA`s and `Owner`s of a `ResourceGroup` returned the same results.
<img width="1492" height="1193" alt="image" src="https://github.com/user-attachments/assets/49812e94-ddeb-4d58-a855-d67678404977" />
<img width="1510" height="1169" alt="image" src="https://github.com/user-attachments/assets/40dbace8-3316-4f8f-9005-e1f7b6fbacc4" />

### After: 
- The cypher query for to find `UAA`s of a `ResourceGroup` now resolve accurately:
<img width="1231" height="700" alt="image" src="https://github.com/user-attachments/assets/038f05ca-e1bc-4656-8883-e6022561d275" />







[BED-7634]: https://specterops.atlassian.net/browse/BED-7634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BED-7634]: https://specterops.atlassian.net/browse/BED-7634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Listing of resource group user access administrators now returns only user-access-admin entries, improving accuracy of administrator results.

* **Tests**
  * Tests updated to include multiple role assignments, validate resource group identity, confirm a single user-access-admin is returned, and fix assertion/error message wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->