### PR TITLE
fix: add tenant info to appfic in order to build correct names BED-7398

### DIFF
--- a/cmd/list-app-federated-identity-credentials.go
+++ b/cmd/list-app-federated-identity-credentials.go
@@ -77,7 +77,9 @@ func listAppFICs(ctx context.Context, client client.AzureClient, apps <-chan azu
 			for app := range stream {
 				var (
 					data = models.AppFICs{
-						AppId: app.Data.AppId,
+						AppId:      app.Data.AppId,
+						TenantId:   client.TenantInfo().TenantId,
+						TenantName: client.TenantInfo().DisplayName,
 					}
 					count = 0
 				)

--- a/models/app-fic.go
+++ b/models/app-fic.go
@@ -43,8 +43,10 @@ func (s *AppFIC) MarshalJSON() ([]byte, error) {
 }
 
 type AppFICs struct {
-	FICs  []AppFIC `json:"fics"`
-	AppId string   `json:"appId"`
+	FICs       []AppFIC `json:"fics"`
+	AppId      string   `json:"appId"`
+	TenantId   string   `json:"tenantId"`
+	TenantName string   `json:"tenantName"`
 }
 
 type FICData struct {


### PR DESCRIPTION
Adds tenant into to AppFic information to build the correct node info

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tenant identification information to app federated identity credentials. When retrieving credentials, you now receive the tenant ID and tenant name alongside existing credential details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->