### PR TITLE
BED-7630: fix: Remove Race Condition From Unit Tests

### DIFF
--- a/cmd/list-app-owners_test.go
+++ b/cmd/list-app-owners_test.go
@@ -78,9 +78,6 @@ func TestListAppOwners(t *testing.T) {
 		}
 	}()
 
-	// Collect both results before asserting. listAppOwners fans out across goroutines
-	// via pipeline.Demux, so output order is non-deterministic. Asserting positionally
-	// produces a flaky test; instead we assert on the set of owner counts.
 	var ownerCounts []int
 	for i := 0; i < 2; i++ {
 		result, ok := <-channel

--- a/cmd/list-app-owners_test.go
+++ b/cmd/list-app-owners_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/bloodhoundad/azurehound/v2/client"
@@ -77,15 +78,20 @@ func TestListAppOwners(t *testing.T) {
 		}
 	}()
 
-	if result, ok := <-channel; !ok {
-		t.Fatalf("failed to receive from channel")
-	} else if len(result.Data.Owners) != 2 {
-		t.Errorf("got %v, want %v", len(result.Data.Owners), 2)
+	// Collect both results before asserting. listAppOwners fans out across goroutines
+	// via pipeline.Demux, so output order is non-deterministic. Asserting positionally
+	// produces a flaky test; instead we assert on the set of owner counts.
+	var ownerCounts []int
+	for i := 0; i < 2; i++ {
+		result, ok := <-channel
+		if !ok {
+			t.Fatalf("failed to receive result %d from channel", i+1)
+		}
+		ownerCounts = append(ownerCounts, len(result.Data.Owners))
 	}
 
-	if result, ok := <-channel; !ok {
-		t.Fatalf("failed to receive from channel")
-	} else if len(result.Data.Owners) != 1 {
-		t.Errorf("got %v, want %v", len(result.Data.Owners), 2)
+	sort.Ints(ownerCounts)
+	if ownerCounts[0] != 1 || ownerCounts[1] != 2 {
+		t.Errorf("expected owner counts [1 2] (in any order), got %v", ownerCounts)
 	}
 }

--- a/cmd/list-group-members_test.go
+++ b/cmd/list-group-members_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/bloodhoundad/azurehound/v2/client"
@@ -80,23 +81,27 @@ func TestListGroupMembers(t *testing.T) {
 		}
 	}()
 
-	if result, ok := <-channel; !ok {
-		t.Fatalf("failed to receive from channel")
-	} else if wrapper, ok := result.(AzureWrapper); !ok {
-		t.Errorf("failed type assertion: got %T, want %T", result, AzureWrapper{})
-	} else if data, ok := wrapper.Data.(models.GroupMembers); !ok {
-		t.Errorf("failed type assertion: got %T, want %T", wrapper.Data, models.GroupMembers{})
-	} else if len(data.Members) != 2 {
-		t.Errorf("got %v, want %v", len(data.Members), 2)
+	// Collect both results before asserting. Asserting positionally
+	// produces flaky test results; instead we assert on the set of member counts.
+	var memberCounts []int
+	for i := 0; i < 2; i++ {
+		result, ok := <-channel
+		if !ok {
+			t.Fatalf("failed to receive result %d from channel", i+1)
+		}
+		wrapper, ok := result.(AzureWrapper)
+		if !ok {
+			t.Fatalf("result %d: failed type assertion: got %T, want %T", i+1, result, AzureWrapper{})
+		}
+		data, ok := wrapper.Data.(models.GroupMembers)
+		if !ok {
+			t.Fatalf("result %d: failed type assertion: got %T, want %T", i+1, wrapper.Data, models.GroupMembers{})
+		}
+		memberCounts = append(memberCounts, len(data.Members))
 	}
 
-	if result, ok := <-channel; !ok {
-		t.Fatalf("failed to receive from channel")
-	} else if wrapper, ok := result.(AzureWrapper); !ok {
-		t.Errorf("failed type assertion: got %T, want %T", result, AzureWrapper{})
-	} else if data, ok := wrapper.Data.(models.GroupMembers); !ok {
-		t.Errorf("failed type assertion: got %T, want %T", wrapper.Data, models.GroupMembers{})
-	} else if len(data.Members) != 1 {
-		t.Errorf("got %v, want %v", len(data.Members), 1)
+	sort.Ints(memberCounts)
+	if memberCounts[0] != 1 || memberCounts[1] != 2 {
+		t.Errorf("expected member counts [1 2] (in any order), got %v", memberCounts)
 	}
 }

--- a/cmd/list-group-members_test.go
+++ b/cmd/list-group-members_test.go
@@ -81,8 +81,6 @@ func TestListGroupMembers(t *testing.T) {
 		}
 	}()
 
-	// Collect both results before asserting. Asserting positionally
-	// produces flaky test results; instead we assert on the set of member counts.
 	var memberCounts []int
 	for i := 0; i < 2; i++ {
 		result, ok := <-channel

--- a/cmd/list-group-owners_test.go
+++ b/cmd/list-group-owners_test.go
@@ -81,9 +81,6 @@ func TestListGroupOwners(t *testing.T) {
 		}
 	}()
 
-	// Collect both results before asserting. listGroupOwners fans out across goroutines
-	// via pipeline.Demux, so output order is non-deterministic. Asserting positionally
-	// produces a flaky test; instead we assert on the set of owner counts.
 	var ownerCounts []int
 	for i := 0; i < 2; i++ {
 		result, ok := <-channel

--- a/cmd/list-group-owners_test.go
+++ b/cmd/list-group-owners_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/bloodhoundad/azurehound/v2/client"
@@ -80,23 +81,28 @@ func TestListGroupOwners(t *testing.T) {
 		}
 	}()
 
-	if result, ok := <-channel; !ok {
-		t.Fatalf("failed to receive from channel")
-	} else if wrapper, ok := result.(AzureWrapper); !ok {
-		t.Errorf("failed type assertion: got %T, want %T", result, AzureWrapper{})
-	} else if data, ok := wrapper.Data.(models.GroupOwners); !ok {
-		t.Errorf("failed type assertion: got %T, want %T", wrapper.Data, models.GroupOwners{})
-	} else if len(data.Owners) != 2 {
-		t.Errorf("got %v, want %v", len(data.Owners), 2)
+	// Collect both results before asserting. listGroupOwners fans out across goroutines
+	// via pipeline.Demux, so output order is non-deterministic. Asserting positionally
+	// produces a flaky test; instead we assert on the set of owner counts.
+	var ownerCounts []int
+	for i := 0; i < 2; i++ {
+		result, ok := <-channel
+		if !ok {
+			t.Fatalf("failed to receive result %d from channel", i+1)
+		}
+		wrapper, ok := result.(AzureWrapper)
+		if !ok {
+			t.Fatalf("result %d: failed type assertion: got %T, want %T", i+1, result, AzureWrapper{})
+		}
+		data, ok := wrapper.Data.(models.GroupOwners)
+		if !ok {
+			t.Fatalf("result %d: failed type assertion: got %T, want %T", i+1, wrapper.Data, models.GroupOwners{})
+		}
+		ownerCounts = append(ownerCounts, len(data.Owners))
 	}
 
-	if result, ok := <-channel; !ok {
-		t.Fatalf("failed to receive from channel")
-	} else if wrapper, ok := result.(AzureWrapper); !ok {
-		t.Errorf("failed type assertion: got %T, want %T", result, AzureWrapper{})
-	} else if data, ok := wrapper.Data.(models.GroupOwners); !ok {
-		t.Errorf("failed type assertion: got %T, want %T", wrapper.Data, models.GroupOwners{})
-	} else if len(data.Owners) != 1 {
-		t.Errorf("got %v, want %v", len(data.Owners), 2)
+	sort.Ints(ownerCounts)
+	if ownerCounts[0] != 1 || ownerCounts[1] != 2 {
+		t.Errorf("expected owner counts [1 2] (in any order), got %v", ownerCounts)
 	}
 }

--- a/cmd/list-key-vault-role-assignments_test.go
+++ b/cmd/list-key-vault-role-assignments_test.go
@@ -20,6 +20,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/bloodhoundad/azurehound/v2/client"
@@ -92,15 +93,20 @@ func TestListKeyVaultRoleAssignments(t *testing.T) {
 		}
 	}()
 
-	if result, ok := <-channel; !ok {
-		t.Fatalf("failed to receive from channel")
-	} else if len(result.Data.RoleAssignments) != 2 {
-		t.Errorf("got %v, want %v", len(result.Data.RoleAssignments), 2)
+	// Collect both results before asserting. listKeyVaultRoleAssignments fans out across
+	// goroutines via pipeline.Demux, so output order is non-deterministic. Asserting
+	// positionally produces a flaky test; instead we assert on the set of counts.
+	var roleCounts []int
+	for i := 0; i < 2; i++ {
+		result, ok := <-channel
+		if !ok {
+			t.Fatalf("failed to receive result %d from channel", i+1)
+		}
+		roleCounts = append(roleCounts, len(result.Data.RoleAssignments))
 	}
 
-	if result, ok := <-channel; !ok {
-		t.Fatalf("failed to receive from channel")
-	} else if len(result.Data.RoleAssignments) != 1 {
-		t.Errorf("got %v, want %v", len(result.Data.RoleAssignments), 1)
+	sort.Ints(roleCounts)
+	if roleCounts[0] != 1 || roleCounts[1] != 2 {
+		t.Errorf("expected role assignment counts [1 2] (in any order), got %v", roleCounts)
 	}
 }

--- a/cmd/list-key-vault-role-assignments_test.go
+++ b/cmd/list-key-vault-role-assignments_test.go
@@ -93,9 +93,6 @@ func TestListKeyVaultRoleAssignments(t *testing.T) {
 		}
 	}()
 
-	// Collect both results before asserting. listKeyVaultRoleAssignments fans out across
-	// goroutines via pipeline.Demux, so output order is non-deterministic. Asserting
-	// positionally produces a flaky test; instead we assert on the set of counts.
 	var roleCounts []int
 	for i := 0; i < 2; i++ {
 		result, ok := <-channel

--- a/cmd/list-management-group-role-assignments_test.go
+++ b/cmd/list-management-group-role-assignments_test.go
@@ -93,9 +93,6 @@ func TestListResourceGroupRoleAssignments(t *testing.T) {
 		}
 	}()
 
-	// Collect both results before asserting. listResourceGroupRoleAssignments fans out
-	// across goroutines via pipeline.Demux, so output order is non-deterministic.
-	// Asserting positionally produces a flaky test; instead we assert on the set of counts.
 	var roleCounts []int
 	for i := 0; i < 2; i++ {
 		result, ok := <-channel

--- a/cmd/list-management-group-role-assignments_test.go
+++ b/cmd/list-management-group-role-assignments_test.go
@@ -20,6 +20,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/bloodhoundad/azurehound/v2/client"
@@ -92,15 +93,20 @@ func TestListResourceGroupRoleAssignments(t *testing.T) {
 		}
 	}()
 
-	if result, ok := <-channel; !ok {
-		t.Fatalf("failed to receive from channel")
-	} else if len(result.Data.RoleAssignments) != 2 {
-		t.Errorf("got %v, want %v", len(result.Data.RoleAssignments), 2)
+	// Collect both results before asserting. listResourceGroupRoleAssignments fans out
+	// across goroutines via pipeline.Demux, so output order is non-deterministic.
+	// Asserting positionally produces a flaky test; instead we assert on the set of counts.
+	var roleCounts []int
+	for i := 0; i < 2; i++ {
+		result, ok := <-channel
+		if !ok {
+			t.Fatalf("failed to receive result %d from channel", i+1)
+		}
+		roleCounts = append(roleCounts, len(result.Data.RoleAssignments))
 	}
 
-	if result, ok := <-channel; !ok {
-		t.Fatalf("failed to receive from channel")
-	} else if len(result.Data.RoleAssignments) != 1 {
-		t.Errorf("got %v, want %v", len(result.Data.RoleAssignments), 2)
+	sort.Ints(roleCounts)
+	if roleCounts[0] != 1 || roleCounts[1] != 2 {
+		t.Errorf("expected role assignment counts [1 2] (in any order), got %v", roleCounts)
 	}
 }

--- a/cmd/list-resource-group-role-assignments_test.go
+++ b/cmd/list-resource-group-role-assignments_test.go
@@ -20,6 +20,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/bloodhoundad/azurehound/v2/client"
@@ -92,15 +93,20 @@ func TestListManagementGroupRoleAssignments(t *testing.T) {
 		}
 	}()
 
-	if result, ok := <-channel; !ok {
-		t.Fatalf("failed to receive from channel")
-	} else if len(result.Data.RoleAssignments) != 2 {
-		t.Errorf("got %v, want %v", len(result.Data.RoleAssignments), 2)
+	// Collect both results before asserting. listManagementGroupRoleAssignments fans out
+	// across goroutines via pipeline.Demux, so output order is non-deterministic.
+	// Asserting positionally produces a flaky test; instead we assert on the set of counts.
+	var roleCounts []int
+	for i := 0; i < 2; i++ {
+		result, ok := <-channel
+		if !ok {
+			t.Fatalf("failed to receive result %d from channel", i+1)
+		}
+		roleCounts = append(roleCounts, len(result.Data.RoleAssignments))
 	}
 
-	if result, ok := <-channel; !ok {
-		t.Fatalf("failed to receive from channel")
-	} else if len(result.Data.RoleAssignments) != 1 {
-		t.Errorf("got %v, want %v", len(result.Data.RoleAssignments), 2)
+	sort.Ints(roleCounts)
+	if roleCounts[0] != 1 || roleCounts[1] != 2 {
+		t.Errorf("expected role assignment counts [1 2] (in any order), got %v", roleCounts)
 	}
 }

--- a/cmd/list-resource-group-role-assignments_test.go
+++ b/cmd/list-resource-group-role-assignments_test.go
@@ -93,9 +93,6 @@ func TestListManagementGroupRoleAssignments(t *testing.T) {
 		}
 	}()
 
-	// Collect both results before asserting. listManagementGroupRoleAssignments fans out
-	// across goroutines via pipeline.Demux, so output order is non-deterministic.
-	// Asserting positionally produces a flaky test; instead we assert on the set of counts.
 	var roleCounts []int
 	for i := 0; i < 2; i++ {
 		result, ok := <-channel

--- a/cmd/list-service-principal-owners_test.go
+++ b/cmd/list-service-principal-owners_test.go
@@ -81,9 +81,6 @@ func TestListServicePrincipalOwners(t *testing.T) {
 		}
 	}()
 
-	// Collect both results before asserting. listServicePrincipalOwners fans out across
-	// goroutines via pipeline.Demux, so output order is non-deterministic. Asserting
-	// positionally produces a flaky test; instead we assert on the set of owner counts.
 	var ownerCounts []int
 	for i := 0; i < 2; i++ {
 		result, ok := <-channel

--- a/cmd/list-service-principal-owners_test.go
+++ b/cmd/list-service-principal-owners_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/bloodhoundad/azurehound/v2/client"
@@ -80,23 +81,28 @@ func TestListServicePrincipalOwners(t *testing.T) {
 		}
 	}()
 
-	if result, ok := <-channel; !ok {
-		t.Fatalf("failed to receive from channel")
-	} else if wrapper, ok := result.(AzureWrapper); !ok {
-		t.Errorf("failed type assertion: got %T, want %T", result, AzureWrapper{})
-	} else if data, ok := wrapper.Data.(models.ServicePrincipalOwners); !ok {
-		t.Errorf("failed type assertion: got %T, want %T", wrapper.Data, models.ServicePrincipalOwners{})
-	} else if len(data.Owners) != 2 {
-		t.Errorf("got %v, want %v", len(data.Owners), 2)
+	// Collect both results before asserting. listServicePrincipalOwners fans out across
+	// goroutines via pipeline.Demux, so output order is non-deterministic. Asserting
+	// positionally produces a flaky test; instead we assert on the set of owner counts.
+	var ownerCounts []int
+	for i := 0; i < 2; i++ {
+		result, ok := <-channel
+		if !ok {
+			t.Fatalf("failed to receive result %d from channel", i+1)
+		}
+		wrapper, ok := result.(AzureWrapper)
+		if !ok {
+			t.Fatalf("result %d: failed type assertion: got %T, want %T", i+1, result, AzureWrapper{})
+		}
+		data, ok := wrapper.Data.(models.ServicePrincipalOwners)
+		if !ok {
+			t.Fatalf("result %d: failed type assertion: got %T, want %T", i+1, wrapper.Data, models.ServicePrincipalOwners{})
+		}
+		ownerCounts = append(ownerCounts, len(data.Owners))
 	}
 
-	if result, ok := <-channel; !ok {
-		t.Fatalf("failed to receive from channel")
-	} else if wrapper, ok := result.(AzureWrapper); !ok {
-		t.Errorf("failed type assertion: got %T, want %T", result, AzureWrapper{})
-	} else if data, ok := wrapper.Data.(models.ServicePrincipalOwners); !ok {
-		t.Errorf("failed type assertion: got %T, want %T", wrapper.Data, models.ServicePrincipalOwners{})
-	} else if len(data.Owners) != 1 {
-		t.Errorf("got %v, want %v", len(data.Owners), 1)
+	sort.Ints(ownerCounts)
+	if ownerCounts[0] != 1 || ownerCounts[1] != 2 {
+		t.Errorf("expected owner counts [1 2] (in any order), got %v", ownerCounts)
 	}
 }

--- a/cmd/list-subscription-role-assignments_test.go
+++ b/cmd/list-subscription-role-assignments_test.go
@@ -93,9 +93,6 @@ func TestListSubscriptionRoleAssignments(t *testing.T) {
 		}
 	}()
 
-	// Collect both results before asserting. listSubscriptionRoleAssignments fans out
-	// across goroutines via pipeline.Demux, so output order is non-deterministic.
-	// Asserting positionally produces a flaky test; instead we assert on the set of counts.
 	var roleCounts []int
 	for i := 0; i < 2; i++ {
 		result, ok := <-channel

--- a/cmd/list-subscription-role-assignments_test.go
+++ b/cmd/list-subscription-role-assignments_test.go
@@ -20,6 +20,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/bloodhoundad/azurehound/v2/client"
@@ -92,23 +93,28 @@ func TestListSubscriptionRoleAssignments(t *testing.T) {
 		}
 	}()
 
-	if result, ok := <-channel; !ok {
-		t.Fatalf("failed to receive from channel")
-	} else if wrapper, ok := result.(AzureWrapper); !ok {
-		t.Errorf("failed type assertion: got %T, want %T", result, AzureWrapper{})
-	} else if data, ok := wrapper.Data.(models.SubscriptionRoleAssignments); !ok {
-		t.Errorf("failed type assertion: got %T, want %T", wrapper.Data, models.SubscriptionRoleAssignments{})
-	} else if len(data.RoleAssignments) != 2 {
-		t.Errorf("got %v, want %v", len(data.RoleAssignments), 2)
+	// Collect both results before asserting. listSubscriptionRoleAssignments fans out
+	// across goroutines via pipeline.Demux, so output order is non-deterministic.
+	// Asserting positionally produces a flaky test; instead we assert on the set of counts.
+	var roleCounts []int
+	for i := 0; i < 2; i++ {
+		result, ok := <-channel
+		if !ok {
+			t.Fatalf("failed to receive result %d from channel", i+1)
+		}
+		wrapper, ok := result.(AzureWrapper)
+		if !ok {
+			t.Fatalf("result %d: failed type assertion: got %T, want %T", i+1, result, AzureWrapper{})
+		}
+		data, ok := wrapper.Data.(models.SubscriptionRoleAssignments)
+		if !ok {
+			t.Fatalf("result %d: failed type assertion: got %T, want %T", i+1, wrapper.Data, models.SubscriptionRoleAssignments{})
+		}
+		roleCounts = append(roleCounts, len(data.RoleAssignments))
 	}
 
-	if result, ok := <-channel; !ok {
-		t.Fatalf("failed to receive from channel")
-	} else if wrapper, ok := result.(AzureWrapper); !ok {
-		t.Errorf("failed type assertion: got %T, want %T", result, AzureWrapper{})
-	} else if data, ok := wrapper.Data.(models.SubscriptionRoleAssignments); !ok {
-		t.Errorf("failed type assertion: got %T, want %T", wrapper.Data, models.SubscriptionRoleAssignments{})
-	} else if len(data.RoleAssignments) != 1 {
-		t.Errorf("got %v, want %v", len(data.RoleAssignments), 2)
+	sort.Ints(roleCounts)
+	if roleCounts[0] != 1 || roleCounts[1] != 2 {
+		t.Errorf("expected role assignment counts [1 2] (in any order), got %v", roleCounts)
 	}
 }

--- a/cmd/list-virtual-machine-role-assignments_test.go
+++ b/cmd/list-virtual-machine-role-assignments_test.go
@@ -93,9 +93,6 @@ func TestListVirtualMachineRoleAssignments(t *testing.T) {
 		}
 	}()
 
-	// Collect both results before asserting. listVirtualMachineRoleAssignments fans out
-	// across goroutines via pipeline.Demux, so output order is non-deterministic.
-	// Asserting positionally produces a flaky test; instead we assert on the set of counts.
 	var roleCounts []int
 	for i := 0; i < 2; i++ {
 		result, ok := <-channel

--- a/cmd/list-virtual-machine-role-assignments_test.go
+++ b/cmd/list-virtual-machine-role-assignments_test.go
@@ -20,6 +20,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/bloodhoundad/azurehound/v2/client"
@@ -92,15 +93,20 @@ func TestListVirtualMachineRoleAssignments(t *testing.T) {
 		}
 	}()
 
-	if result, ok := <-channel; !ok {
-		t.Fatalf("failed to receive from channel")
-	} else if len(result.Data.RoleAssignments) != 2 {
-		t.Errorf("got %v, want %v", len(result.Data.RoleAssignments), 2)
+	// Collect both results before asserting. listVirtualMachineRoleAssignments fans out
+	// across goroutines via pipeline.Demux, so output order is non-deterministic.
+	// Asserting positionally produces a flaky test; instead we assert on the set of counts.
+	var roleCounts []int
+	for i := 0; i < 2; i++ {
+		result, ok := <-channel
+		if !ok {
+			t.Fatalf("failed to receive result %d from channel", i+1)
+		}
+		roleCounts = append(roleCounts, len(result.Data.RoleAssignments))
 	}
 
-	if result, ok := <-channel; !ok {
-		t.Fatalf("failed to receive from channel")
-	} else if len(result.Data.RoleAssignments) != 1 {
-		t.Errorf("got %v, want %v", len(result.Data.RoleAssignments), 2)
+	sort.Ints(roleCounts)
+	if roleCounts[0] != 1 || roleCounts[1] != 2 {
+		t.Errorf("expected role assignment counts [1 2] (in any order), got %v", roleCounts)
 	}
 }


### PR DESCRIPTION
[Ticket](https://specterops.atlassian.net/browse/BED-7630)

Several unit tests were intermittently failing on CI. The root cause is that the test functions split work across multiple goroutines concurrently, so results can arrive in any order. The tests were written assuming a fixed output order.. For example, asserting that the first result always has 2 members and the second always has 1. That assumption is a race condition, which caused the tests to fail intermittently in CI. 

The fix: instead of reading results one-by-one and checking each by position, the tests now collect all results first, then sort and assert on actual values/output. This makes the assertions true regardless of which result arrives first.

To test: 
- Run the `Test` action multiple times and observe that there are no longer intermittent failures.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated many tests to be order-independent when reading concurrent results: they now collect multiple receives, sort counts, and assert expected multisets rather than rely on receive order. Failures on closed channels or bad types are now reported as immediate test failures with indexed messages, improving reliability and clearer diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->