### PR TITLE
BED-7664: Strengthen AzureHound unit tests to verify output data

### DIFF
--- a/cmd/list-key-vault-contributors_test.go
+++ b/cmd/list-key-vault-contributors_test.go
@@ -53,9 +53,17 @@ func TestListKeyVaultContributors(t *testing.T) {
 			RoleAssignments: []models.KeyVaultRoleAssignment{
 				{
 					RoleAssignment: azure.RoleAssignment{
-						Name: constants.ContributorRoleID,
+						Name: "matching-assignment",
 						Properties: azure.RoleAssignmentPropertiesWithScope{
 							RoleDefinitionId: constants.ContributorRoleID,
+						},
+					},
+				},
+				{
+					RoleAssignment: azure.RoleAssignment{
+						Name: "non-matching-assignment",
+						Properties: azure.RoleAssignmentPropertiesWithScope{
+							RoleDefinitionId: constants.OwnerRoleID,
 						},
 					},
 				},
@@ -63,11 +71,29 @@ func TestListKeyVaultContributors(t *testing.T) {
 		})
 	}()
 
-	if _, ok := <-channel; !ok {
+	result, ok := <-channel
+	if !ok {
 		t.Fatalf("failed to receive from channel")
 	}
 
+	wrapper, ok := result.(azureWrapper[models.KeyVaultContributors])
+	if !ok {
+		t.Fatalf("unexpected type in channel: %T", result)
+	}
+
+	if wrapper.Data.KeyVaultId != "foo" {
+		t.Errorf("expected KeyVaultId 'foo', got '%s'", wrapper.Data.KeyVaultId)
+	}
+
+	if len(wrapper.Data.Contributors) != 1 {
+		t.Fatalf("expected 1 contributor, got %d", len(wrapper.Data.Contributors))
+	}
+
+	if wrapper.Data.Contributors[0].Contributor.Name != "matching-assignment" {
+		t.Errorf("expected contributor name 'matching-assignment', got '%s'", wrapper.Data.Contributors[0].Contributor.Name)
+	}
+
 	if _, ok := <-channel; ok {
-		t.Error("should not have recieved from channel")
+		t.Error("should not have received from channel")
 	}
 }

--- a/cmd/list-key-vault-kvcontributors_test.go
+++ b/cmd/list-key-vault-kvcontributors_test.go
@@ -55,9 +55,17 @@ func TestListKeyVaultKVContributors(t *testing.T) {
 				RoleAssignments: []models.KeyVaultRoleAssignment{
 					{
 						RoleAssignment: azure.RoleAssignment{
-							Name: constants.KeyVaultContributorRoleID,
+							Name: "matching-assignment",
 							Properties: azure.RoleAssignmentPropertiesWithScope{
 								RoleDefinitionId: constants.KeyVaultContributorRoleID,
+							},
+						},
+					},
+					{
+						RoleAssignment: azure.RoleAssignment{
+							Name: "non-matching-assignment",
+							Properties: azure.RoleAssignmentPropertiesWithScope{
+								RoleDefinitionId: constants.OwnerRoleID,
 							},
 						},
 					},
@@ -66,11 +74,29 @@ func TestListKeyVaultKVContributors(t *testing.T) {
 		)
 	}()
 
-	if _, ok := <-channel; !ok {
+	result, ok := <-channel
+	if !ok {
 		t.Fatalf("failed to receive from channel")
 	}
 
+	wrapper, ok := result.(azureWrapper[models.KeyVaultKVContributors])
+	if !ok {
+		t.Fatalf("unexpected type in channel: %T", result)
+	}
+
+	if wrapper.Data.KeyVaultId != "foo" {
+		t.Errorf("expected KeyVaultId 'foo', got '%s'", wrapper.Data.KeyVaultId)
+	}
+
+	if len(wrapper.Data.KVContributors) != 1 {
+		t.Fatalf("expected 1 kv contributor, got %d", len(wrapper.Data.KVContributors))
+	}
+
+	if wrapper.Data.KVContributors[0].KVContributor.Name != "matching-assignment" {
+		t.Errorf("expected kv contributor name 'matching-assignment', got '%s'", wrapper.Data.KVContributors[0].KVContributor.Name)
+	}
+
 	if _, ok := <-channel; ok {
-		t.Error("should not have recieved from channel")
+		t.Error("should not have received from channel")
 	}
 }

--- a/cmd/list-key-vault-owners_test.go
+++ b/cmd/list-key-vault-owners_test.go
@@ -55,9 +55,17 @@ func TestListKeyVaultOwners(t *testing.T) {
 				RoleAssignments: []models.KeyVaultRoleAssignment{
 					{
 						RoleAssignment: azure.RoleAssignment{
-							Name: constants.OwnerRoleID,
+							Name: "matching-assignment",
 							Properties: azure.RoleAssignmentPropertiesWithScope{
 								RoleDefinitionId: constants.OwnerRoleID,
+							},
+						},
+					},
+					{
+						RoleAssignment: azure.RoleAssignment{
+							Name: "non-matching-assignment",
+							Properties: azure.RoleAssignmentPropertiesWithScope{
+								RoleDefinitionId: constants.ContributorRoleID,
 							},
 						},
 					},
@@ -66,11 +74,29 @@ func TestListKeyVaultOwners(t *testing.T) {
 		)
 	}()
 
-	if _, ok := <-channel; !ok {
+	result, ok := <-channel
+	if !ok {
 		t.Fatalf("failed to receive from channel")
 	}
 
+	wrapper, ok := result.(azureWrapper[models.KeyVaultOwners])
+	if !ok {
+		t.Fatalf("unexpected type in channel: %T", result)
+	}
+
+	if wrapper.Data.KeyVaultId != "foo" {
+		t.Errorf("expected KeyVaultId 'foo', got '%s'", wrapper.Data.KeyVaultId)
+	}
+
+	if len(wrapper.Data.Owners) != 1 {
+		t.Fatalf("expected 1 owner, got %d", len(wrapper.Data.Owners))
+	}
+
+	if wrapper.Data.Owners[0].Owner.Name != "matching-assignment" {
+		t.Errorf("expected owner name 'matching-assignment', got '%s'", wrapper.Data.Owners[0].Owner.Name)
+	}
+
 	if _, ok := <-channel; ok {
-		t.Error("should not have recieved from channel")
+		t.Error("should not have received from channel")
 	}
 }

--- a/cmd/list-key-vault-user-access-admins_test.go
+++ b/cmd/list-key-vault-user-access-admins_test.go
@@ -55,9 +55,17 @@ func TestListKeyVaultUserAccessAdmins(t *testing.T) {
 				RoleAssignments: []models.KeyVaultRoleAssignment{
 					{
 						RoleAssignment: azure.RoleAssignment{
-							Name: constants.UserAccessAdminRoleID,
+							Name: "matching-assignment",
 							Properties: azure.RoleAssignmentPropertiesWithScope{
 								RoleDefinitionId: constants.UserAccessAdminRoleID,
+							},
+						},
+					},
+					{
+						RoleAssignment: azure.RoleAssignment{
+							Name: "non-matching-assignment",
+							Properties: azure.RoleAssignmentPropertiesWithScope{
+								RoleDefinitionId: constants.OwnerRoleID,
 							},
 						},
 					},
@@ -66,11 +74,29 @@ func TestListKeyVaultUserAccessAdmins(t *testing.T) {
 		)
 	}()
 
-	if _, ok := <-channel; !ok {
+	result, ok := <-channel
+	if !ok {
 		t.Fatalf("failed to receive from channel")
 	}
 
+	wrapper, ok := result.(azureWrapper[models.KeyVaultUserAccessAdmins])
+	if !ok {
+		t.Fatalf("unexpected type in channel: %T", result)
+	}
+
+	if wrapper.Data.KeyVaultId != "foo" {
+		t.Errorf("expected KeyVaultId 'foo', got '%s'", wrapper.Data.KeyVaultId)
+	}
+
+	if len(wrapper.Data.UserAccessAdmins) != 1 {
+		t.Fatalf("expected 1 user access admin, got %d", len(wrapper.Data.UserAccessAdmins))
+	}
+
+	if wrapper.Data.UserAccessAdmins[0].UserAccessAdmin.Name != "matching-assignment" {
+		t.Errorf("expected user access admin name 'matching-assignment', got '%s'", wrapper.Data.UserAccessAdmins[0].UserAccessAdmin.Name)
+	}
+
 	if _, ok := <-channel; ok {
-		t.Error("should not have recieved from channel")
+		t.Error("should not have received from channel")
 	}
 }

--- a/cmd/list-management-group-owners_test.go
+++ b/cmd/list-management-group-owners_test.go
@@ -55,9 +55,17 @@ func TestListManagementGroupOwners(t *testing.T) {
 				RoleAssignments: []models.ManagementGroupRoleAssignment{
 					{
 						RoleAssignment: azure.RoleAssignment{
-							Name: constants.OwnerRoleID,
+							Name: "matching-assignment",
 							Properties: azure.RoleAssignmentPropertiesWithScope{
 								RoleDefinitionId: constants.OwnerRoleID,
+							},
+						},
+					},
+					{
+						RoleAssignment: azure.RoleAssignment{
+							Name: "non-matching-assignment",
+							Properties: azure.RoleAssignmentPropertiesWithScope{
+								RoleDefinitionId: constants.ContributorRoleID,
 							},
 						},
 					},
@@ -66,11 +74,29 @@ func TestListManagementGroupOwners(t *testing.T) {
 		)
 	}()
 
-	if _, ok := <-channel; !ok {
+	result, ok := <-channel
+	if !ok {
 		t.Fatalf("failed to receive from channel")
 	}
 
+	wrapper, ok := result.(azureWrapper[models.ManagementGroupOwners])
+	if !ok {
+		t.Fatalf("unexpected type in channel: %T", result)
+	}
+
+	if wrapper.Data.ManagementGroupId != "foo" {
+		t.Errorf("expected ManagementGroupId 'foo', got '%s'", wrapper.Data.ManagementGroupId)
+	}
+
+	if len(wrapper.Data.Owners) != 1 {
+		t.Fatalf("expected 1 owner, got %d", len(wrapper.Data.Owners))
+	}
+
+	if wrapper.Data.Owners[0].Owner.Name != "matching-assignment" {
+		t.Errorf("expected owner name 'matching-assignment', got '%s'", wrapper.Data.Owners[0].Owner.Name)
+	}
+
 	if _, ok := <-channel; ok {
-		t.Error("should not have recieved from channel")
+		t.Error("should not have received from channel")
 	}
 }

--- a/cmd/list-management-group-user-access-admins_test.go
+++ b/cmd/list-management-group-user-access-admins_test.go
@@ -55,9 +55,17 @@ func TestListManagementGroupUserAccessAdmins(t *testing.T) {
 				RoleAssignments: []models.ManagementGroupRoleAssignment{
 					{
 						RoleAssignment: azure.RoleAssignment{
-							Name: constants.UserAccessAdminRoleID,
+							Name: "matching-assignment",
 							Properties: azure.RoleAssignmentPropertiesWithScope{
 								RoleDefinitionId: constants.UserAccessAdminRoleID,
+							},
+						},
+					},
+					{
+						RoleAssignment: azure.RoleAssignment{
+							Name: "non-matching-assignment",
+							Properties: azure.RoleAssignmentPropertiesWithScope{
+								RoleDefinitionId: constants.OwnerRoleID,
 							},
 						},
 					},
@@ -66,11 +74,29 @@ func TestListManagementGroupUserAccessAdmins(t *testing.T) {
 		)
 	}()
 
-	if _, ok := <-channel; !ok {
+	result, ok := <-channel
+	if !ok {
 		t.Fatalf("failed to receive from channel")
 	}
 
+	wrapper, ok := result.(azureWrapper[models.ManagementGroupUserAccessAdmins])
+	if !ok {
+		t.Fatalf("unexpected type in channel: %T", result)
+	}
+
+	if wrapper.Data.ManagementGroupId != "foo" {
+		t.Errorf("expected ManagementGroupId 'foo', got '%s'", wrapper.Data.ManagementGroupId)
+	}
+
+	if len(wrapper.Data.UserAccessAdmins) != 1 {
+		t.Fatalf("expected 1 user access admin, got %d", len(wrapper.Data.UserAccessAdmins))
+	}
+
+	if wrapper.Data.UserAccessAdmins[0].UserAccessAdmin.Name != "matching-assignment" {
+		t.Errorf("expected user access admin name 'matching-assignment', got '%s'", wrapper.Data.UserAccessAdmins[0].UserAccessAdmin.Name)
+	}
+
 	if _, ok := <-channel; ok {
-		t.Error("should not have recieved from channel")
+		t.Error("should not have received from channel")
 	}
 }

--- a/cmd/list-resource-group-owners_test.go
+++ b/cmd/list-resource-group-owners_test.go
@@ -55,9 +55,17 @@ func TestListResourceGroupOwners(t *testing.T) {
 				RoleAssignments: []models.ResourceGroupRoleAssignment{
 					{
 						RoleAssignment: azure.RoleAssignment{
-							Name: constants.OwnerRoleID,
+							Name: "matching-assignment",
 							Properties: azure.RoleAssignmentPropertiesWithScope{
 								RoleDefinitionId: constants.OwnerRoleID,
+							},
+						},
+					},
+					{
+						RoleAssignment: azure.RoleAssignment{
+							Name: "non-matching-assignment",
+							Properties: azure.RoleAssignmentPropertiesWithScope{
+								RoleDefinitionId: constants.ContributorRoleID,
 							},
 						},
 					},
@@ -66,11 +74,29 @@ func TestListResourceGroupOwners(t *testing.T) {
 		)
 	}()
 
-	if _, ok := <-channel; !ok {
+	result, ok := <-channel
+	if !ok {
 		t.Fatalf("failed to receive from channel")
 	}
 
+	wrapper, ok := result.(azureWrapper[models.ResourceGroupOwners])
+	if !ok {
+		t.Fatalf("unexpected type in channel: %T", result)
+	}
+
+	if wrapper.Data.ResourceGroupId != "foo" {
+		t.Errorf("expected ResourceGroupId 'foo', got '%s'", wrapper.Data.ResourceGroupId)
+	}
+
+	if len(wrapper.Data.Owners) != 1 {
+		t.Fatalf("expected 1 owner, got %d", len(wrapper.Data.Owners))
+	}
+
+	if wrapper.Data.Owners[0].Owner.Name != "matching-assignment" {
+		t.Errorf("expected owner name 'matching-assignment', got '%s'", wrapper.Data.Owners[0].Owner.Name)
+	}
+
 	if _, ok := <-channel; ok {
-		t.Error("should not have recieved from channel")
+		t.Error("should not have received from channel")
 	}
 }

--- a/cmd/list-subscription-owners_test.go
+++ b/cmd/list-subscription-owners_test.go
@@ -53,9 +53,17 @@ func TestListSubscriptionOwners(t *testing.T) {
 				RoleAssignments: []models.SubscriptionRoleAssignment{
 					{
 						RoleAssignment: azure.RoleAssignment{
-							Name: constants.OwnerRoleID,
+							Name: "matching-assignment",
 							Properties: azure.RoleAssignmentPropertiesWithScope{
 								RoleDefinitionId: constants.OwnerRoleID,
+							},
+						},
+					},
+					{
+						RoleAssignment: azure.RoleAssignment{
+							Name: "non-matching-assignment",
+							Properties: azure.RoleAssignmentPropertiesWithScope{
+								RoleDefinitionId: constants.ContributorRoleID,
 							},
 						},
 					},
@@ -64,15 +72,34 @@ func TestListSubscriptionOwners(t *testing.T) {
 		}
 	}()
 
-	if result, ok := <-channel; !ok {
+	result, ok := <-channel
+	if !ok {
 		t.Fatalf("failed to receive from channel")
-	} else if wrapper, ok := result.(AzureWrapper); !ok {
-		t.Errorf("failed type assertion: got %T, want %T", result, AzureWrapper{})
-	} else if _, ok := wrapper.Data.(models.SubscriptionOwners); !ok {
-		t.Errorf("failed type assertion: got %T, want %T", wrapper.Data, models.SubscriptionOwners{})
+	}
+
+	wrapper, ok := result.(AzureWrapper)
+	if !ok {
+		t.Fatalf("failed type assertion: got %T, want %T", result, AzureWrapper{})
+	}
+
+	data, ok := wrapper.Data.(models.SubscriptionOwners)
+	if !ok {
+		t.Fatalf("failed type assertion: got %T, want %T", wrapper.Data, models.SubscriptionOwners{})
+	}
+
+	if data.SubscriptionId != "foo" {
+		t.Errorf("expected SubscriptionId 'foo', got '%s'", data.SubscriptionId)
+	}
+
+	if len(data.Owners) != 1 {
+		t.Fatalf("expected 1 owner, got %d", len(data.Owners))
+	}
+
+	if data.Owners[0].Owner.Name != "matching-assignment" {
+		t.Errorf("expected owner name 'matching-assignment', got '%s'", data.Owners[0].Owner.Name)
 	}
 
 	if _, ok := <-channel; ok {
-		t.Error("should not have recieved from channel")
+		t.Error("should not have received from channel")
 	}
 }

--- a/cmd/list-subscription-user-access-admins_test.go
+++ b/cmd/list-subscription-user-access-admins_test.go
@@ -53,9 +53,17 @@ func TestListSubscriptionUserAccessAdmins(t *testing.T) {
 				RoleAssignments: []models.SubscriptionRoleAssignment{
 					{
 						RoleAssignment: azure.RoleAssignment{
-							Name: constants.UserAccessAdminRoleID,
+							Name: "matching-assignment",
 							Properties: azure.RoleAssignmentPropertiesWithScope{
 								RoleDefinitionId: constants.UserAccessAdminRoleID,
+							},
+						},
+					},
+					{
+						RoleAssignment: azure.RoleAssignment{
+							Name: "non-matching-assignment",
+							Properties: azure.RoleAssignmentPropertiesWithScope{
+								RoleDefinitionId: constants.OwnerRoleID,
 							},
 						},
 					},
@@ -64,15 +72,34 @@ func TestListSubscriptionUserAccessAdmins(t *testing.T) {
 		}
 	}()
 
-	if result, ok := <-channel; !ok {
+	result, ok := <-channel
+	if !ok {
 		t.Fatalf("failed to receive from channel")
-	} else if wrapper, ok := result.(AzureWrapper); !ok {
-		t.Errorf("failed type assertion: got %T, want %T", result, AzureWrapper{})
-	} else if _, ok := wrapper.Data.(models.SubscriptionUserAccessAdmins); !ok {
-		t.Errorf("failed type assertion: got %T, want %T", wrapper.Data, models.SubscriptionUserAccessAdmins{})
+	}
+
+	wrapper, ok := result.(AzureWrapper)
+	if !ok {
+		t.Fatalf("failed type assertion: got %T, want %T", result, AzureWrapper{})
+	}
+
+	data, ok := wrapper.Data.(models.SubscriptionUserAccessAdmins)
+	if !ok {
+		t.Fatalf("failed type assertion: got %T, want %T", wrapper.Data, models.SubscriptionUserAccessAdmins{})
+	}
+
+	if data.SubscriptionId != "foo" {
+		t.Errorf("expected SubscriptionId 'foo', got '%s'", data.SubscriptionId)
+	}
+
+	if len(data.UserAccessAdmins) != 1 {
+		t.Fatalf("expected 1 user access admin, got %d", len(data.UserAccessAdmins))
+	}
+
+	if data.UserAccessAdmins[0].UserAccessAdmin.Name != "matching-assignment" {
+		t.Errorf("expected user access admin name 'matching-assignment', got '%s'", data.UserAccessAdmins[0].UserAccessAdmin.Name)
 	}
 
 	if _, ok := <-channel; ok {
-		t.Error("should not have recieved from channel")
+		t.Error("should not have received from channel")
 	}
 }

--- a/cmd/list-virtual-machine-admin-logins_test.go
+++ b/cmd/list-virtual-machine-admin-logins_test.go
@@ -55,9 +55,17 @@ func TestListVirtualMachineAdminLogins(t *testing.T) {
 				RoleAssignments: []models.VirtualMachineRoleAssignment{
 					{
 						RoleAssignment: azure.RoleAssignment{
-							Name: constants.VirtualMachineAdministratorLoginRoleID,
+							Name: "matching-assignment",
 							Properties: azure.RoleAssignmentPropertiesWithScope{
 								RoleDefinitionId: constants.VirtualMachineAdministratorLoginRoleID,
+							},
+						},
+					},
+					{
+						RoleAssignment: azure.RoleAssignment{
+							Name: "non-matching-assignment",
+							Properties: azure.RoleAssignmentPropertiesWithScope{
+								RoleDefinitionId: constants.OwnerRoleID,
 							},
 						},
 					},
@@ -66,11 +74,29 @@ func TestListVirtualMachineAdminLogins(t *testing.T) {
 		)
 	}()
 
-	if _, ok := <-channel; !ok {
+	result, ok := <-channel
+	if !ok {
 		t.Fatalf("failed to receive from channel")
 	}
 
+	wrapper, ok := result.(azureWrapper[models.VirtualMachineAdminLogins])
+	if !ok {
+		t.Fatalf("unexpected type in channel: %T", result)
+	}
+
+	if wrapper.Data.VirtualMachineId != "foo" {
+		t.Errorf("expected VirtualMachineId 'foo', got '%s'", wrapper.Data.VirtualMachineId)
+	}
+
+	if len(wrapper.Data.AdminLogins) != 1 {
+		t.Fatalf("expected 1 admin login, got %d", len(wrapper.Data.AdminLogins))
+	}
+
+	if wrapper.Data.AdminLogins[0].AdminLogin.Name != "matching-assignment" {
+		t.Errorf("expected admin login name 'matching-assignment', got '%s'", wrapper.Data.AdminLogins[0].AdminLogin.Name)
+	}
+
 	if _, ok := <-channel; ok {
-		t.Error("should not have recieved from channel")
+		t.Error("should not have received from channel")
 	}
 }

--- a/cmd/list-virtual-machine-avere-contributors_test.go
+++ b/cmd/list-virtual-machine-avere-contributors_test.go
@@ -55,9 +55,17 @@ func TestListVirtualMachineAvereContributors(t *testing.T) {
 				RoleAssignments: []models.VirtualMachineRoleAssignment{
 					{
 						RoleAssignment: azure.RoleAssignment{
-							Name: constants.AvereContributorRoleID,
+							Name: "matching-assignment",
 							Properties: azure.RoleAssignmentPropertiesWithScope{
 								RoleDefinitionId: constants.AvereContributorRoleID,
+							},
+						},
+					},
+					{
+						RoleAssignment: azure.RoleAssignment{
+							Name: "non-matching-assignment",
+							Properties: azure.RoleAssignmentPropertiesWithScope{
+								RoleDefinitionId: constants.OwnerRoleID,
 							},
 						},
 					},
@@ -66,11 +74,29 @@ func TestListVirtualMachineAvereContributors(t *testing.T) {
 		)
 	}()
 
-	if _, ok := <-channel; !ok {
+	result, ok := <-channel
+	if !ok {
 		t.Fatalf("failed to receive from channel")
 	}
 
+	wrapper, ok := result.(azureWrapper[models.VirtualMachineAvereContributors])
+	if !ok {
+		t.Fatalf("unexpected type in channel: %T", result)
+	}
+
+	if wrapper.Data.VirtualMachineId != "foo" {
+		t.Errorf("expected VirtualMachineId 'foo', got '%s'", wrapper.Data.VirtualMachineId)
+	}
+
+	if len(wrapper.Data.AvereContributors) != 1 {
+		t.Fatalf("expected 1 avere contributor, got %d", len(wrapper.Data.AvereContributors))
+	}
+
+	if wrapper.Data.AvereContributors[0].AvereContributor.Name != "matching-assignment" {
+		t.Errorf("expected avere contributor name 'matching-assignment', got '%s'", wrapper.Data.AvereContributors[0].AvereContributor.Name)
+	}
+
 	if _, ok := <-channel; ok {
-		t.Error("should not have recieved from channel")
+		t.Error("should not have received from channel")
 	}
 }

--- a/cmd/list-virtual-machine-contributors_test.go
+++ b/cmd/list-virtual-machine-contributors_test.go
@@ -55,9 +55,17 @@ func TestListVirtualMachineContributors(t *testing.T) {
 				RoleAssignments: []models.VirtualMachineRoleAssignment{
 					{
 						RoleAssignment: azure.RoleAssignment{
-							Name: constants.ContributorRoleID,
+							Name: "matching-assignment",
 							Properties: azure.RoleAssignmentPropertiesWithScope{
 								RoleDefinitionId: constants.ContributorRoleID,
+							},
+						},
+					},
+					{
+						RoleAssignment: azure.RoleAssignment{
+							Name: "non-matching-assignment",
+							Properties: azure.RoleAssignmentPropertiesWithScope{
+								RoleDefinitionId: constants.OwnerRoleID,
 							},
 						},
 					},
@@ -66,11 +74,29 @@ func TestListVirtualMachineContributors(t *testing.T) {
 		)
 	}()
 
-	if _, ok := <-channel; !ok {
+	result, ok := <-channel
+	if !ok {
 		t.Fatalf("failed to receive from channel")
 	}
 
+	wrapper, ok := result.(azureWrapper[models.VirtualMachineContributors])
+	if !ok {
+		t.Fatalf("unexpected type in channel: %T", result)
+	}
+
+	if wrapper.Data.VirtualMachineId != "foo" {
+		t.Errorf("expected VirtualMachineId 'foo', got '%s'", wrapper.Data.VirtualMachineId)
+	}
+
+	if len(wrapper.Data.Contributors) != 1 {
+		t.Fatalf("expected 1 contributor, got %d", len(wrapper.Data.Contributors))
+	}
+
+	if wrapper.Data.Contributors[0].Contributor.Name != "matching-assignment" {
+		t.Errorf("expected contributor name 'matching-assignment', got '%s'", wrapper.Data.Contributors[0].Contributor.Name)
+	}
+
 	if _, ok := <-channel; ok {
-		t.Error("should not have recieved from channel")
+		t.Error("should not have received from channel")
 	}
 }

--- a/cmd/list-virtual-machine-owners_test.go
+++ b/cmd/list-virtual-machine-owners_test.go
@@ -55,9 +55,17 @@ func TestListVirtualMachineOwners(t *testing.T) {
 				RoleAssignments: []models.VirtualMachineRoleAssignment{
 					{
 						RoleAssignment: azure.RoleAssignment{
-							Name: constants.OwnerRoleID,
+							Name: "matching-assignment",
 							Properties: azure.RoleAssignmentPropertiesWithScope{
 								RoleDefinitionId: constants.OwnerRoleID,
+							},
+						},
+					},
+					{
+						RoleAssignment: azure.RoleAssignment{
+							Name: "non-matching-assignment",
+							Properties: azure.RoleAssignmentPropertiesWithScope{
+								RoleDefinitionId: constants.ContributorRoleID,
 							},
 						},
 					},
@@ -66,11 +74,29 @@ func TestListVirtualMachineOwners(t *testing.T) {
 		)
 	}()
 
-	if _, ok := <-channel; !ok {
+	result, ok := <-channel
+	if !ok {
 		t.Fatalf("failed to receive from channel")
 	}
 
+	wrapper, ok := result.(azureWrapper[models.VirtualMachineOwners])
+	if !ok {
+		t.Fatalf("unexpected type in channel: %T", result)
+	}
+
+	if wrapper.Data.VirtualMachineId != "foo" {
+		t.Errorf("expected VirtualMachineId 'foo', got '%s'", wrapper.Data.VirtualMachineId)
+	}
+
+	if len(wrapper.Data.Owners) != 1 {
+		t.Fatalf("expected 1 owner, got %d", len(wrapper.Data.Owners))
+	}
+
+	if wrapper.Data.Owners[0].Owner.Name != "matching-assignment" {
+		t.Errorf("expected owner name 'matching-assignment', got '%s'", wrapper.Data.Owners[0].Owner.Name)
+	}
+
 	if _, ok := <-channel; ok {
-		t.Error("should not have recieved from channel")
+		t.Error("should not have received from channel")
 	}
 }

--- a/cmd/list-virtual-machine-user-access-admins_test.go
+++ b/cmd/list-virtual-machine-user-access-admins_test.go
@@ -55,9 +55,17 @@ func TestListVirtualMachineUserAccessAdmins(t *testing.T) {
 				RoleAssignments: []models.VirtualMachineRoleAssignment{
 					{
 						RoleAssignment: azure.RoleAssignment{
-							Name: constants.UserAccessAdminRoleID,
+							Name: "matching-assignment",
 							Properties: azure.RoleAssignmentPropertiesWithScope{
 								RoleDefinitionId: constants.UserAccessAdminRoleID,
+							},
+						},
+					},
+					{
+						RoleAssignment: azure.RoleAssignment{
+							Name: "non-matching-assignment",
+							Properties: azure.RoleAssignmentPropertiesWithScope{
+								RoleDefinitionId: constants.OwnerRoleID,
 							},
 						},
 					},
@@ -66,11 +74,29 @@ func TestListVirtualMachineUserAccessAdmins(t *testing.T) {
 		)
 	}()
 
-	if _, ok := <-channel; !ok {
+	result, ok := <-channel
+	if !ok {
 		t.Fatalf("failed to receive from channel")
 	}
 
+	wrapper, ok := result.(azureWrapper[models.VirtualMachineUserAccessAdmins])
+	if !ok {
+		t.Fatalf("unexpected type in channel: %T", result)
+	}
+
+	if wrapper.Data.VirtualMachineId != "foo" {
+		t.Errorf("expected VirtualMachineId 'foo', got '%s'", wrapper.Data.VirtualMachineId)
+	}
+
+	if len(wrapper.Data.UserAccessAdmins) != 1 {
+		t.Fatalf("expected 1 user access admin, got %d", len(wrapper.Data.UserAccessAdmins))
+	}
+
+	if wrapper.Data.UserAccessAdmins[0].UserAccessAdmin.Name != "matching-assignment" {
+		t.Errorf("expected user access admin name 'matching-assignment', got '%s'", wrapper.Data.UserAccessAdmins[0].UserAccessAdmin.Name)
+	}
+
 	if _, ok := <-channel; ok {
-		t.Error("should not have recieved from channel")
+		t.Error("should not have received from channel")
 	}
 }

--- a/cmd/list-virtual-machine-vmcontributors_test.go
+++ b/cmd/list-virtual-machine-vmcontributors_test.go
@@ -55,9 +55,17 @@ func TestListVirtualMachineVMContributors(t *testing.T) {
 				RoleAssignments: []models.VirtualMachineRoleAssignment{
 					{
 						RoleAssignment: azure.RoleAssignment{
-							Name: constants.VirtualMachineContributorRoleID,
+							Name: "matching-assignment",
 							Properties: azure.RoleAssignmentPropertiesWithScope{
 								RoleDefinitionId: constants.VirtualMachineContributorRoleID,
+							},
+						},
+					},
+					{
+						RoleAssignment: azure.RoleAssignment{
+							Name: "non-matching-assignment",
+							Properties: azure.RoleAssignmentPropertiesWithScope{
+								RoleDefinitionId: constants.OwnerRoleID,
 							},
 						},
 					},
@@ -66,11 +74,29 @@ func TestListVirtualMachineVMContributors(t *testing.T) {
 		)
 	}()
 
-	if _, ok := <-channel; !ok {
+	result, ok := <-channel
+	if !ok {
 		t.Fatalf("failed to receive from channel")
 	}
 
+	wrapper, ok := result.(azureWrapper[models.VirtualMachineVMContributors])
+	if !ok {
+		t.Fatalf("unexpected type in channel: %T", result)
+	}
+
+	if wrapper.Data.VirtualMachineId != "foo" {
+		t.Errorf("expected VirtualMachineId 'foo', got '%s'", wrapper.Data.VirtualMachineId)
+	}
+
+	if len(wrapper.Data.VMContributors) != 1 {
+		t.Fatalf("expected 1 vm contributor, got %d", len(wrapper.Data.VMContributors))
+	}
+
+	if wrapper.Data.VMContributors[0].VMContributor.Name != "matching-assignment" {
+		t.Errorf("expected vm contributor name 'matching-assignment', got '%s'", wrapper.Data.VMContributors[0].VMContributor.Name)
+	}
+
 	if _, ok := <-channel; ok {
-		t.Error("should not have recieved from channel")
+		t.Error("should not have received from channel")
 	}
 }


### PR DESCRIPTION
Ticket: [BED-7664](https://specterops.atlassian.net/browse/BED-7664) 

A good amount of existing unit tests only assert that a message arrives on the channel, but they never actually verify the output or that the filter works properly. Because of this, they are essentially smoke tests to make sure the channels work, but they don’t prevent any logic bugs in the filtering or data mapping.

In this PR, I have added some extra assertions to existing unit tests to actually verify the output and confirm the filters are functioning as expected, as well as updated some of the mock data to improve readability. Each test now has positive and negative tests, which ensure that each filter only collects types that it expects and ignores ones that it does not expect.

Testing: no-op, as long as CI/CD tests pass then we are good to go ✅ 

[BED-7664]: https://specterops.atlassian.net/browse/BED-7664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests

* **Enhanced test coverage** across 18 test files to validate filtering and output content instead of only checking channel closure. Tests now verify that role assignments are correctly filtered based on role type and that output contains expected identifiers and counts. Minor spelling corrections applied to error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->