### PR TITLE
BED-7784: Fix ECR push failure in containerize CI step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,6 +100,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: ${{ ! startsWith(github.event_name, 'pull_request') }}
+          provenance: false
           secrets: |
             GIT_AUTH_TOKEN=${{ secrets.PACKAGE_SCOPE }}
 


### PR DESCRIPTION
Ticket: https://specterops.atlassian.net/browse/BED-7784

Adds `provenance: false` to the `Push Image` step in the build workflow. 

Recent GitHub Actions runner updates changed Docker Buildx's default behavior to include "provenance attestations" (metadata) when pushing images. AWS ECR doesn't support the manifest format used by these attestations, causing the push to fail with a 403 Forbidden. This disables the attestation metadata on push. The image itself not affected.

Ref: https://github.com/docker/build-push-action/issues/826

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image build configuration for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->