### PR TITLE
BED-7784: disable provenance in publish image step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -195,5 +195,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true
+          provenance: false
           secrets: |
             GIT_AUTH_TOKEN=${{ secrets.PACKAGE_SCOPE }}


### PR DESCRIPTION
Ticket: https://specterops.atlassian.net/browse/BED-7784

Adds provenance: false to the Push Image step in the `publish` workflow.

Recent GitHub Actions runner updates changed Docker Buildx's default behavior to include "provenance attestations" (metadata) when pushing images. AWS ECR doesn't support the manifest format used by these attestations, causing the push to fail with a 403 Forbidden. This disables the attestation metadata on push. The image itself not affected.

Already made this change to the `build` step in [this pr](https://github.com/SpecterOps/AzureHound/pull/182), but forgot to make the same change for the `publish` step which is what I am doing here.

Ref: https://github.com/docker/build-push-action/issues/826

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container build pipeline configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->