### PR TITLE
BED-7784: re-enable provenance, revert changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: ${{ ! startsWith(github.event_name, 'pull_request') }}
-          provenance: false
           secrets: |
             GIT_AUTH_TOKEN=${{ secrets.PACKAGE_SCOPE }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -195,6 +195,5 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true
-          provenance: false
           secrets: |
             GIT_AUTH_TOKEN=${{ secrets.PACKAGE_SCOPE }}


### PR DESCRIPTION
Reverts provenance: false from build.yml and publish.yml. The ECR push 403 was likely caused by stale credentials, not `provenance` as previously thought.  Keys have been rotated and pushes seem to be working again.

Ticket: https://specterops.atlassian.net/browse/BED-7784


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container build workflows to enable provenance attestation for published images, improving supply chain security and image verification capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->