### PR TITLE
Funky pagination error (vibe coded fix with Opus) on big Entra tenants with massive groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -237,3 +237,6 @@ tags
 
 # Built Visual Studio Code Extensions
 *.vsix
+
+# AI
+.claude/

--- a/client/rest/client.go
+++ b/client/rest/client.go
@@ -22,6 +22,7 @@ package rest
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -216,13 +217,38 @@ func (s *restClient) send(req *http.Request) (*http.Response, error) {
 					ExponentialBackoff(retry)
 					continue
 				} else {
-					// Not a status code that warrants a retry
-					var errRes map[string]interface{}
-					if err := Decode(res.Body, &errRes); err != nil {
+					// Not a status code that warrants a retry. Read the body once
+					// and try to decode it as a Microsoft Graph-shaped error
+					// envelope so callers can programmatically detect specific
+					// codes (e.g. Directory_ExpiredPageToken). Fall back to the
+					// original map-stringification behavior for non-Graph shapes
+					// (e.g. Resource Manager errors) so existing callers don't
+					// regress.
+					bodyBytes, readErr := io.ReadAll(res.Body)
+					res.Body.Close()
+					if readErr != nil || len(bodyBytes) == 0 {
 						return nil, fmt.Errorf("malformed error response, status code: %d", res.StatusCode)
-					} else {
-						return nil, fmt.Errorf("%v", errRes)
 					}
+
+					var graphEnvelope struct {
+						Error struct {
+							Code    string `json:"code"`
+							Message string `json:"message"`
+						} `json:"error"`
+					}
+					if err := json.Unmarshal(bodyBytes, &graphEnvelope); err == nil && graphEnvelope.Error.Code != "" {
+						return nil, &GraphError{
+							StatusCode: res.StatusCode,
+							Code:       graphEnvelope.Error.Code,
+							Message:    graphEnvelope.Error.Message,
+						}
+					}
+
+					var errRes map[string]interface{}
+					if err := json.Unmarshal(bodyBytes, &errRes); err != nil {
+						return nil, fmt.Errorf("malformed error response, status code: %d", res.StatusCode)
+					}
+					return nil, fmt.Errorf("%v", errRes)
 				}
 			} else {
 				// Response OK

--- a/client/rest/errors.go
+++ b/client/rest/errors.go
@@ -1,0 +1,46 @@
+// Copyright (C) 2022 Specter Ops, Inc.
+//
+// This file is part of AzureHound.
+//
+// AzureHound is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// AzureHound is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package rest
+
+import (
+	"errors"
+	"fmt"
+)
+
+// GraphError is a structured representation of a Microsoft Graph error
+// response body ({"error": {"code": "...", "message": "..."}}). It is
+// returned by the REST layer when a 4xx response decodes to that shape so
+// callers can programmatically detect specific error codes.
+type GraphError struct {
+	StatusCode int
+	Code       string
+	Message    string
+}
+
+func (e *GraphError) Error() string {
+	return fmt.Sprintf("graph error %d: %s - %s", e.StatusCode, e.Code, e.Message)
+}
+
+// IsExpiredPageToken reports whether err (or anything it wraps) is a Graph
+// error with code "Directory_ExpiredPageToken", indicating the pagination
+// cursor in @odata.nextLink has expired and the enumeration must be
+// restarted from scratch.
+func IsExpiredPageToken(err error) bool {
+	var ge *GraphError
+	return errors.As(err, &ge) && ge.Code == "Directory_ExpiredPageToken"
+}

--- a/cmd/list-group-members.go
+++ b/cmd/list-group-members.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/bloodhoundad/azurehound/v2/client"
 	"github.com/bloodhoundad/azurehound/v2/client/query"
+	"github.com/bloodhoundad/azurehound/v2/client/rest"
 	"github.com/bloodhoundad/azurehound/v2/config"
 	"github.com/bloodhoundad/azurehound/v2/enums"
 	"github.com/bloodhoundad/azurehound/v2/models"
@@ -102,25 +103,54 @@ func listGroupMembers(ctx context.Context, client client.AzureClient, groups <-c
 			defer panicrecovery.PanicRecovery()
 			defer wg.Done()
 			for id := range stream {
+				// Microsoft Graph pagination cursors embedded in @odata.nextLink
+				// can expire mid-enumeration for large groups (error code
+				// Directory_ExpiredPageToken). This is independent of the OAuth
+				// access token's lifetime. When it happens, the only recourse is
+				// to restart the member enumeration from scratch so Graph issues
+				// a fresh cursor. Retry per-group with a bounded attempt count.
+				const maxAttempts = 4
 				var (
-					data = models.GroupMembers{
-						GroupId: id,
-					}
-					count = 0
+					data  models.GroupMembers
+					count int
 				)
-				for item := range client.ListAzureADGroupMembers(ctx, id, params) {
-					if item.Error != nil {
-						log.Error(item.Error, "unable to continue processing members for this group", "groupId", id)
-					} else {
-						groupMember := models.GroupMember{
-							Member:  item.Ok,
-							GroupId: id,
+				for attempt := 1; attempt <= maxAttempts; attempt++ {
+					data = models.GroupMembers{GroupId: id}
+					count = 0
+					expired := false
+
+					for item := range client.ListAzureADGroupMembers(ctx, id, params) {
+						if item.Error != nil {
+							if rest.IsExpiredPageToken(item.Error) {
+								expired = true
+								log.Info("page token expired mid-enumeration, will retry group",
+									"groupId", id, "attempt", attempt, "collectedSoFar", count)
+								// Producer already returned after emitting the error;
+								// the channel will close and this range will exit.
+								continue
+							}
+							log.Error(item.Error, "unable to continue processing members for this group",
+								"groupId", id, "attempt", attempt)
+						} else {
+							groupMember := models.GroupMember{
+								Member:  item.Ok,
+								GroupId: id,
+							}
+							log.V(2).Info("found group member", "groupId", groupMember.GroupId)
+							count++
+							data.Members = append(data.Members, groupMember)
 						}
-						log.V(2).Info("found group member", "groupId", groupMember.GroupId)
-						count++
-						data.Members = append(data.Members, groupMember)
+					}
+
+					if !expired {
+						break
+					}
+					if attempt == maxAttempts {
+						log.Error(fmt.Errorf("exhausted %d retries due to Directory_ExpiredPageToken", maxAttempts),
+							"group members may be incomplete", "groupId", id, "partialCount", count)
 					}
 				}
+
 				if ok := pipeline.SendAny(ctx.Done(), out, AzureWrapper{
 					Kind: enums.KindAZGroupMember,
 					Data: data,


### PR DESCRIPTION
Vibe coded a funky pagination error when using azurehound on an enormous Entra tenant with massive groups.

This pull request is to confirm if the patch is sound 😬

(also added .claude to the .gitignore)

ERROR:
ERR unable to continue processing members for this group error="map[error:map[code:Directory_ExpiredPageToken innerError:map[client-request-id:123...456 date:2026-04-21T17:58:12 request-id:123...456] message:The specified page token value has expired and can no longer be included in your request.]]" groupId=123...456 

The "token value has expired" is not an OAuth expiration, but rather (according to Claude Opus), it is a pagination error.

"""
The error is Directory_ExpiredPageToken — not the OAuth access token you're thinking of (the 1h one). It's the Microsoft Graph pagination cursor embedded in the @odata.nextLink URL (an opaque $skiptoken). That cursor has a much shorter, undocumented TTL than your JWT, and it expires when a single group's pagination session stretches too long.

Three things in the AzureHound code conspire to stretch it:

1. No default $top for group members. client/groups.go:63-72 doesn't set params.Top, so Graph's implicit default (~100) is used. A 100k-member group is ~1000 page round-trips. Every sibling endpoint (users, devices, SPs, app role assignments) sets Top=999 — group members is the odd one out.

2. 25 parallel streams hammer Graph. cmd/list-group-members.go:70 fans out with config.ColStreamCount (default 25). Graph throttles, the 429 handler at client/rest/client.go:205 sleeps for Retry-After between every page. Enough elapsed wall-clock time between pages for that specific group and its cursor expires.

3. Current behavior silently accepts partial data. cmd/list-group-members.go:112-114 logs item.Error but keeps going and emits whatever it had collected — so you got an incomplete membership set for group 123..., not just a noisy log.
Also, client/rest/client.go:218-226 stringifies 4xx bodies via fmt.Errorf("%v", errRes), which is why the error code is buried in a stringified map — callers can't programmatically detect it to retry.
"""
 - Claude Opus

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Group member enumeration now automatically retries when pagination token expiration occurs, ensuring more complete results for large groups.
* **Improvements**
  * Enhanced error handling and reporting for Microsoft Graph API responses with detailed status codes and messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->