### PR TITLE
fix: BED-8163 revert artifact actions to v4 to fix release signing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
           outputs: type=oci,dest=/tmp/oci-image.tar
 
       - name: Upload OCI tarball
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4.6.2
         with:
           name: oci-image-tar
           path: /tmp/oci-image.tar

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Upload as Artifact
         if: matrix.os == 'windows'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4.6.2
         with:
           name: azurehound-bin-${{ matrix.os }}-${{ matrix.arch }}
           path: azurehound*
@@ -86,7 +86,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.BHE_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v8
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # ratchet:actions/download-artifact@v4.3.0
         with:
           pattern: azurehound-bin-${{ matrix.os }}-${{ matrix.arch }}
           path: unsigned/


### PR DESCRIPTION
Resolves: [BED-8163](https://specterops.atlassian.net/browse/BED-8163)

In the 2.12.1-rc1 initial release, the signing step failed due to a breaking change in the newest versions of actions/upload-artifact and actions/download-artifact - there is some additional work we need to do in the pipeline to support the breaking changes. This will require another ticket to go back and update the versions as well as the pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow action versions to maintain compatibility and security standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[BED-8163]: https://specterops.atlassian.net/browse/BED-8163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ