### PR TITLE
fix: update rolling build version string to comply with semver - BED-8176

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # ratchet:docker/build-push-action@v7
         with:
           context: .
-          build-args: VERSION=v0.0.0-rolling+${{ github.sha }}
+          build-args: VERSION=v0.0.0
           tags: azurehound # temporary tag to simplify oci conversion
           labels: ${{ steps.meta.outputs.labels }}
           push: false
@@ -96,7 +96,7 @@ jobs:
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # ratchet:docker/build-push-action@v7
         with:
           context: .
-          build-args: VERSION=v0.0.0-rolling+${{ github.sha }}
+          build-args: VERSION=v0.0.0
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: ${{ ! startsWith(github.event_name, 'pull_request') }}
@@ -132,10 +132,10 @@ jobs:
         continue-on-error: true
         run: |
           echo "Generating Windows resources..."
-          go run winres/generate-windows-resources/generate-windows-resources.go "v0.0.0-rolling+${{ github.sha }}"
+          go run winres/generate-windows-resources/generate-windows-resources.go "v0.0.0"
 
       - name: Build
-        run: 'go build -ldflags="-s -w -X github.com/bloodhoundad/azurehound/v2/constants.Version=v0.0.0-rolling+${{ github.sha }}"'
+        run: 'go build -ldflags="-s -w -X github.com/bloodhoundad/azurehound/v2/constants.Version=v0.0.0"'
         env:
           GOOS: ${{ matrix.os }}
           GOARCH: ${{ matrix.arch }}


### PR DESCRIPTION
Currently, the `edge-*` images that infra uses to host our AzH container are named v0.0.0-rolling+<sha>+docker, which is not proper semver, so BHE does not accept data from the client. 

In this PR, we remove the `rolling+<sha>` from the rolling release version name so that it is now proper semver and therefore is able to communicate with BHE. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified build version management across all build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->