### PR TITLE
Apply custom --user-agent to BHE ingest requests

### DIFF
--- a/client/bloodhound/client.go
+++ b/client/bloodhound/client.go
@@ -182,7 +182,7 @@ func (s *BHEClient) Ingest(ctx context.Context, in <-chan []any) bool {
 			s.log.Error(err, unrecoverableErrMsg)
 			return true
 		} else {
-			req.Header.Set("User-Agent", constants.UserAgent())
+			req.Header.Set("User-Agent", rest.UserAgent())
 			req.Header.Set("Accept", "application/json")
 			req.Header.Set("Content-Encoding", "gzip")
 

--- a/client/bloodhound/client_test.go
+++ b/client/bloodhound/client_test.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/bloodhoundad/azurehound/v2/config"
+	"github.com/bloodhoundad/azurehound/v2/constants"
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/http2"
@@ -140,5 +142,52 @@ func TestBHEClient_Ingest(t *testing.T) {
 		hadErrors := client.Ingest(context.Background(), data)
 
 		require.True(t, hadErrors)
+	})
+
+	t.Run("custom user agent applied", func(t *testing.T) {
+		const custom = "test-agent/9.9.9"
+		config.UserAgent.Set(custom)
+		t.Cleanup(func() { config.UserAgent.Set("") })
+
+		var got string
+		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			got = r.Header.Get("User-Agent")
+			w.WriteHeader(http.StatusAccepted)
+		}))
+		defer testServer.Close()
+
+		testUrl, _ := url.Parse(testServer.URL)
+		client, err := NewBHEClient(*testUrl, "tokenId", "token", "", 1, 1, logr.Logger{})
+		require.NoError(t, err)
+
+		data := make(chan []any, 1)
+		data <- []any{"test"}
+		close(data)
+
+		require.False(t, client.Ingest(context.Background(), data))
+		require.Equal(t, custom, got)
+	})
+
+	t.Run("default user agent when config empty", func(t *testing.T) {
+		config.UserAgent.Set("")
+		t.Cleanup(func() { config.UserAgent.Set("") })
+
+		var got string
+		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			got = r.Header.Get("User-Agent")
+			w.WriteHeader(http.StatusAccepted)
+		}))
+		defer testServer.Close()
+
+		testUrl, _ := url.Parse(testServer.URL)
+		client, err := NewBHEClient(*testUrl, "tokenId", "token", "", 1, 1, logr.Logger{})
+		require.NoError(t, err)
+
+		data := make(chan []any, 1)
+		data <- []any{"test"}
+		close(data)
+
+		require.False(t, client.Ingest(context.Background(), data))
+		require.Equal(t, constants.UserAgent(), got)
 	})
 }

--- a/client/rest/http.go
+++ b/client/rest/http.go
@@ -129,12 +129,17 @@ func NewRequest(
 		}
 
 		// set azurehound as user-agent, use custom if set in config
-		ua := config.UserAgent.Value()
-		if s, ok := ua.(string); ok && s != "" {
-			req.Header.Set("User-Agent", s)
-		} else {
-			req.Header.Set("User-Agent", constants.UserAgent())
-		}
+		req.Header.Set("User-Agent", UserAgent())
 		return req, nil
 	}
+}
+
+// UserAgent returns the configured User-Agent header value, falling back to
+// the default azurehound/<version> string when the --user-agent flag is unset
+// or empty.
+func UserAgent() string {
+	if s, ok := config.UserAgent.Value().(string); ok && s != "" {
+		return s
+	}
+	return constants.UserAgent()
 }

--- a/client/rest/http_test.go
+++ b/client/rest/http_test.go
@@ -1,0 +1,75 @@
+// Copyright (C) 2026 Specter Ops, Inc.
+//
+// This file is part of AzureHound.
+//
+// AzureHound is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// AzureHound is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package rest
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/bloodhoundad/azurehound/v2/config"
+	"github.com/bloodhoundad/azurehound/v2/constants"
+)
+
+func TestUserAgent_DefaultsWhenUnset(t *testing.T) {
+	config.UserAgent.Set("")
+	t.Cleanup(func() { config.UserAgent.Set("") })
+
+	if got, want := UserAgent(), constants.UserAgent(); got != want {
+		t.Fatalf("UserAgent() = %q, want default %q", got, want)
+	}
+}
+
+func TestUserAgent_HonorsConfigValue(t *testing.T) {
+	const custom = "my-custom-agent/1.2.3"
+	config.UserAgent.Set(custom)
+	t.Cleanup(func() { config.UserAgent.Set("") })
+
+	if got := UserAgent(); got != custom {
+		t.Fatalf("UserAgent() = %q, want %q", got, custom)
+	}
+}
+
+func TestNewRequest_AppliesCustomUserAgent(t *testing.T) {
+	const custom = "my-custom-agent/1.2.3"
+	config.UserAgent.Set(custom)
+	t.Cleanup(func() { config.UserAgent.Set("") })
+
+	endpoint, _ := url.Parse("http://example.com/")
+	req, err := NewRequest(context.Background(), "GET", endpoint, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("NewRequest error: %v", err)
+	}
+	if got := req.Header.Get("User-Agent"); got != custom {
+		t.Fatalf("User-Agent header = %q, want %q", got, custom)
+	}
+}
+
+func TestNewRequest_DefaultUserAgentWhenConfigEmpty(t *testing.T) {
+	config.UserAgent.Set("")
+	t.Cleanup(func() { config.UserAgent.Set("") })
+
+	endpoint, _ := url.Parse("http://example.com/")
+	req, err := NewRequest(context.Background(), "GET", endpoint, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("NewRequest error: %v", err)
+	}
+	if got, want := req.Header.Get("User-Agent"), constants.UserAgent(); got != want {
+		t.Fatalf("User-Agent header = %q, want default %q", got, want)
+	}
+}


### PR DESCRIPTION
The `--user-agent` global flag added in f7bf368 only flows through `rest.NewRequest`. The BHE ingest path in `BHEClient.Ingest` builds its request inline and hardcodes the default `azurehound/<version>` value, so `/api/v2/ingest` still gets the default UA even when `--user-agent` is set.

This finishes plumbing the flag everywhere by:

- pulling the resolution logic out of `rest.NewRequest` into a small `rest.UserAgent()` helper,
- using that helper in both `rest.NewRequest` and `BHEClient.Ingest`.

Closes #135.

## Tests

`client/rest/http_test.go` (new):
- `TestUserAgent_DefaultsWhenUnset` / `TestUserAgent_HonorsConfigValue`
- `TestNewRequest_AppliesCustomUserAgent` / `TestNewRequest_DefaultUserAgentWhenConfigEmpty`

`client/bloodhound/client_test.go` (added subtests on `TestBHEClient_Ingest`):
- `custom user agent applied` — spins up an httptest server, sets `config.UserAgent`, verifies the recorded UA on `/api/v2/ingest`
- `default user agent when config empty` — same harness with the flag unset, verifies fallback to `constants.UserAgent()`

Local run:

```
go build ./...
go test ./...
go vet ./...
```

All green.

## Notes

- No flag/CLI surface change; `--user-agent` (`-U`) was already in `GlobalConfig`.
- Pure refactor + additional call site, no behavior change for the default path.
- I left the existing inline comment intact in spirit but moved the implementation; happy to rename the helper or shape the diff differently if you'd prefer it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved User-Agent header handling to ensure consistent configuration across HTTP requests.

* **Tests**
  * Added tests to validate User-Agent header behavior with custom configurations and default values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->