### PR TITLE
chore: update upload/download GH actions + update signing step - BED-8167

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
           outputs: type=oci,dest=/tmp/oci-image.tar
 
       - name: Upload OCI tarball
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7.0.1
         with:
           name: oci-image-tar
           path: /tmp/oci-image.tar

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Upload as Artifact
         if: matrix.os == 'windows'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7.0.1
         with:
           name: azurehound-bin-${{ matrix.os }}-${{ matrix.arch }}
           path: azurehound*
@@ -86,10 +86,10 @@ jobs:
           aws-secret-access-key: ${{ secrets.BHE_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # ratchet:actions/download-artifact@v4.3.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v8.0.1
         with:
-          pattern: azurehound-bin-${{ matrix.os }}-${{ matrix.arch }}
-          path: unsigned/
+          name: azurehound-bin-${{ matrix.os }}-${{ matrix.arch }}
+          path: unsigned/azurehound-bin-${{ matrix.os }}-${{ matrix.arch }}
 
       - name: Install osslsigncode & pkcs11 engine
         run: |


### PR DESCRIPTION
Summary: This PR brings two actions (`upload-artifact` & `download-artifact`) back to the latest versions and adjusts the publish workflow / sign step so it works correctly with the new behavior.

Resolves BED-8167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD artifact upload and download actions to newer releases for improved reliability.
  * Made artifact handling more specific (name-based paths) to ensure correct files are used during signing and publishing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SpecterOps/AzureHound/pull/195)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->