### PR TITLE
chore: migrate digicert signing action to Node.js 24 successor - BED-8168

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Install DigiCert Client Tools
         id: digicert
-        uses: digicert/ssm-code-signing@1d820463733701cf1484c7eb5d7d24a15ca2c454 # ratchet:digicert/ssm-code-signing@v1.2.1
+        uses: digicert/code-signing-software-trust-action@fae23a455ba4bde62b64fd7cb2f81ade788f5a95 # ratchet:digicert/code-signing-software-trust-action@v1.2.1
 
       - name: Set PKCS#11 Paths
         id: pkcs11

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,8 @@ on:
   push:
     tags:
       - v*.*.*
-  workflow_dispatch:
+  pull_request: # TODO(BED-8168): remove before merge
+    branches: [main]
 env:
   AZUREHOUND_VERSION: ${{ github.ref_name }}
 jobs:
@@ -60,7 +61,7 @@ jobs:
         run: sha256sum ${{ env.FILE_NAME }}.zip > ${{ env.FILE_NAME }}.zip.sha256
 
       - name: Upload Release
-        if: github.event_name != 'workflow_dispatch'
+        if: github.event_name != 'pull_request' # TODO(BED-8168): remove before merge
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # ratchet:softprops/action-gh-release@v3
         with:
           files: |
@@ -136,12 +137,12 @@ jobs:
           sha256sum zipped/${{ env.FILE_NAME }}.zip > zipped/${{ env.FILE_NAME }}.zip.sha256
 
       - name: Upload Artifacts to S3
-        if: github.event_name != 'workflow_dispatch'
+        if: github.event_name != 'pull_request' # TODO(BED-8168): remove before merge
         run: |
           aws s3 cp --recursive zipped/ s3://${{ secrets.BHE_AWS_BUCKET }}
 
   containerize:
-    if: github.event_name != 'workflow_dispatch'
+    if: github.event_name != 'pull_request' # TODO(BED-8168): remove before merge
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,56 +91,31 @@ jobs:
           name: azurehound-bin-${{ matrix.os }}-${{ matrix.arch }}
           path: unsigned/azurehound-bin-${{ matrix.os }}-${{ matrix.arch }}
 
-      - name: Install osslsigncode & pkcs11 engine
+      - name: Setup SM_CLIENT_CERT_FILE
+        shell: bash
         run: |
-          sudo apt-get update
-          sudo apt-get install -y osslsigncode libengine-pkcs11-openssl
+          export SM_CLIENT_CERT_FILE=${RUNNER_TEMP}/Certifiact_pkcs12.p12
+          echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > ${SM_CLIENT_CERT_FILE}
+          echo "SM_CLIENT_CERT_FILE=${SM_CLIENT_CERT_FILE}" >> $GITHUB_ENV
 
-      - name: Install DigiCert Client Tools
+      - name: Setup Software Trust Manager & Sign
         id: digicert
         uses: digicert/code-signing-software-trust-action@fae23a455ba4bde62b64fd7cb2f81ade788f5a95 # ratchet:digicert/code-signing-software-trust-action@v1.2.1
-
-      - name: Set PKCS#11 Paths
-        id: pkcs11
-        run: |
-          SM_TOOLS_DIR=$(dirname "$(realpath '${{ steps.digicert.outputs.PKCS11_CONFIG }}')")
-          echo "module=${SM_TOOLS_DIR}/smpkcs11.so" >> "$GITHUB_OUTPUT"
-          LIB_PKCS11="$(dpkg -L libengine-pkcs11-openssl | grep "libpkcs11.so")"
-          echo "engine=$LIB_PKCS11" >> "$GITHUB_OUTPUT"
-
-      - name: Sign Artifacts via DigiCert Signing Manager
+        with:
+          simple-signing-mode: true
+          input: unsigned/azurehound-bin-${{ matrix.os }}-${{ matrix.arch }}/azurehound.exe
+          keypair-alias: ${{ secrets.SM_KEYPAIR_ALIAS }}
         env:
           SM_HOST: ${{ secrets.SM_HOST }}
           SM_API_KEY: ${{ secrets.SM_API_KEY }}
-          SM_CLIENT_CERT_FILE_B64: ${{ secrets.SM_CLIENT_CERT_FILE_B64 }}
+          SM_CLIENT_CERT_FILE: ${{ env.SM_CLIENT_CERT_FILE}}
           SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
+
+      - name: Move Signed Artifacts
         shell: bash
         run: |
-          export SM_CLIENT_CERT_FILE=$(mktemp)
-          printenv SM_CLIENT_CERT_FILE_B64 | base64 --decode > "$SM_CLIENT_CERT_FILE"
-          trap 'rm $SM_CLIENT_CERT_FILE' EXIT
-
           mkdir signed
-          artifact=unsigned/azurehound-bin-${{ matrix.os }}-${{ matrix.arch }}/azurehound.exe
-          smctl sign --keypair-alias "${{ secrets.SM_KEYPAIR_ALIAS }}" --input "$artifact" --openssl-pkcs11-engine "${{ steps.pkcs11.outputs.engine }}" --pkcs11-module "${{ steps.pkcs11.outputs.module }}" --tool osslsigncode --verbose
-          mv "$artifact" "signed/azurehound.exe"
-
-      - name: Verify Signed Artifacts
-        env:
-          SM_HOST: ${{ secrets.SM_HOST }}
-          SM_API_KEY: ${{ secrets.SM_API_KEY }}
-          SM_CLIENT_CERT_FILE_B64: ${{ secrets.SM_CLIENT_CERT_FILE_B64 }}
-          SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
-        shell: bash
-        run: |
-          export SM_CLIENT_CERT_FILE=$(mktemp)
-          printenv SM_CLIENT_CERT_FILE_B64 | base64 --decode > "$SM_CLIENT_CERT_FILE"
-          smctl certificate download --keypair-alias "${{ secrets.SM_KEYPAIR_ALIAS }}" --format pem --chain --name cert-chain.pem
-          trap 'rm $SM_CLIENT_CERT_FILE cert-chain.pem' EXIT
-
-          for artifact in signed/*; do
-            osslsigncode verify -CAfile cert-chain.pem "$artifact"
-          done
+          mv unsigned/azurehound-bin-${{ matrix.os }}-${{ matrix.arch }}/azurehound.exe signed/azurehound.exe
 
       - name: Zip Signed Executables
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - v*.*.*
-  pull_request: # TODO(BED-8168): remove before merge
-    branches: [main]
 env:
   AZUREHOUND_VERSION: ${{ github.ref_name }}
 jobs:
@@ -61,7 +59,6 @@ jobs:
         run: sha256sum ${{ env.FILE_NAME }}.zip > ${{ env.FILE_NAME }}.zip.sha256
 
       - name: Upload Release
-        if: github.event_name != 'pull_request' # TODO(BED-8168): remove before merge
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # ratchet:softprops/action-gh-release@v3
         with:
           files: |
@@ -137,12 +134,10 @@ jobs:
           sha256sum zipped/${{ env.FILE_NAME }}.zip > zipped/${{ env.FILE_NAME }}.zip.sha256
 
       - name: Upload Artifacts to S3
-        if: github.event_name != 'pull_request' # TODO(BED-8168): remove before merge
         run: |
           aws s3 cp --recursive zipped/ s3://${{ secrets.BHE_AWS_BUCKET }}
 
   containerize:
-    if: github.event_name != 'pull_request' # TODO(BED-8168): remove before merge
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - v*.*.*
+  workflow_dispatch:
 env:
   AZUREHOUND_VERSION: ${{ github.ref_name }}
 jobs:
@@ -59,6 +60,7 @@ jobs:
         run: sha256sum ${{ env.FILE_NAME }}.zip > ${{ env.FILE_NAME }}.zip.sha256
 
       - name: Upload Release
+        if: github.event_name != 'workflow_dispatch'
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # ratchet:softprops/action-gh-release@v3
         with:
           files: |
@@ -93,10 +95,12 @@ jobs:
 
       - name: Setup SM_CLIENT_CERT_FILE
         shell: bash
+        env:
+          SM_CLIENT_CERT_FILE_B64: ${{ secrets.SM_CLIENT_CERT_FILE_B64 }}
         run: |
-          export SM_CLIENT_CERT_FILE=${RUNNER_TEMP}/Certifiact_pkcs12.p12
-          echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > ${SM_CLIENT_CERT_FILE}
-          echo "SM_CLIENT_CERT_FILE=${SM_CLIENT_CERT_FILE}" >> $GITHUB_ENV
+          SM_CLIENT_CERT_FILE="${RUNNER_TEMP}/Certificate_pkcs12.p12"
+          printenv SM_CLIENT_CERT_FILE_B64 | base64 --decode > "$SM_CLIENT_CERT_FILE"
+          echo "SM_CLIENT_CERT_FILE=${SM_CLIENT_CERT_FILE}" >> "$GITHUB_ENV"
 
       - name: Setup Software Trust Manager & Sign
         id: digicert
@@ -110,6 +114,11 @@ jobs:
           SM_API_KEY: ${{ secrets.SM_API_KEY }}
           SM_CLIENT_CERT_FILE: ${{ env.SM_CLIENT_CERT_FILE}}
           SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
+
+      - name: Cleanup cert file
+        if: always()
+        shell: bash
+        run: rm -f "${{ env.SM_CLIENT_CERT_FILE }}"
 
       - name: Move Signed Artifacts
         shell: bash
@@ -127,10 +136,12 @@ jobs:
           sha256sum zipped/${{ env.FILE_NAME }}.zip > zipped/${{ env.FILE_NAME }}.zip.sha256
 
       - name: Upload Artifacts to S3
+        if: github.event_name != 'workflow_dispatch'
         run: |
           aws s3 cp --recursive zipped/ s3://${{ secrets.BHE_AWS_BUCKET }}
 
   containerize:
+    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       packages: write


### PR DESCRIPTION
digicert/ssm-code-signing has been deprecated by the upstream maintainer and will not receive further updates, including a Node.js 24 runtime upgrade. Per the maintainer's post, migrate to the successor action `digicert/code-signing-software-trust-action@v1.2.1`, which runs on Node.js 24. Needed because our runners will stop being able to run node20 dependencies later this year

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Code signing switched to DigiCert's code-signing action using a transient decoded certificate.
  * Legacy signing toolchain and its verification loop were removed.
  * Signed Windows executables are produced and placed in a dedicated signed location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->