### PR TITLE
chore: Remove Unneeded Creds from Build - BED-8282

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,8 +81,6 @@ jobs:
           tags: azurehound # temporary tag to simplify oci conversion
           labels: ${{ steps.meta.outputs.labels }}
           push: false
-          secrets: |
-            GIT_AUTH_TOKEN=${{ secrets.PACKAGE_SCOPE }}
           # Multi-platform builds can not be loaded into local Docker Daemon
           outputs: type=oci,dest=/tmp/oci-image.tar
 
@@ -100,8 +98,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: ${{ ! startsWith(github.event_name, 'pull_request') }}
-          secrets: |
-            GIT_AUTH_TOKEN=${{ secrets.PACKAGE_SCOPE }}
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -195,5 +195,3 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true
-          secrets: |
-            GIT_AUTH_TOKEN=${{ secrets.PACKAGE_SCOPE }}


### PR DESCRIPTION
This change removes unnecessary Credentials that are being passed into the Dockerfile. Since they are unused, it is removed. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD container build configuration to stop passing build-time secret variables during image build and push steps, while retaining existing tagging, labeling, and push behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SpecterOps/AzureHound/pull/200?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->