### PR TITLE
fix: drop `appId` uppercasing in `AppRoleAssignment.MarshalJSON` (BED-9235)

### DIFF
--- a/models/app-role-assignments.go
+++ b/models/app-role-assignments.go
@@ -34,7 +34,6 @@ func (s AppRoleAssignment) MarshalJSON() ([]byte, error) {
 	type Alias AppRoleAssignment
 	a := Alias(s)
 	a.ResourceId = strings.ToUpper(a.ResourceId)
-	a.AppId = strings.ToUpper(a.AppId)
 	a.TenantId = strings.ToUpper(a.TenantId)
 
 	// PrincipalId is a uuid.UUID and cannot hold an uppercased string, so emit

--- a/models/marshal_test.go
+++ b/models/marshal_test.go
@@ -276,7 +276,7 @@ func TestAppRoleAssignmentMarshalJSONUppercasesUUIDFields(t *testing.T) {
 
 	require.Equal(t, "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE", out["principalId"])
 	require.Equal(t, "RESOURCE-1", out["resourceId"])
-	require.Equal(t, "APP-1", out["appId"])
+	require.Equal(t, "app-1", out["appId"])
 	require.Equal(t, "TENANT-1", out["tenantId"])
 	// AppRoleId is used for lowercase matching in ingest and must remain untouched.
 	require.Equal(t, "11111111-2222-3333-4444-555555555555", out["appRoleId"])


### PR DESCRIPTION
## Description

BED-9100 (`c8fdff7`) uppercased `appId`, but `appId` is a constant-match key, not a node endpoint. BHE compares it verbatim against the lowercase Microsoft Graph app id (`00000003-0000-0000-c000-000000000000`) via a case-sensitive `==` to build the
`AZMG*` edges. Uppercasing broke that match and silently dropped ~2.29M edges. This reverts `appId` to the casing every other producer already emits (v3.0.0, BARK, the Graph API). `resourceId`/`tenantId`/`principalId` stay uppercased — those are real endpoints the raw-ingest path needs.

Fixed in the collector (not BHE) because the regression is collector-side and this works against all existing BHE versions with no deploy.

## Motivation and Context
Resolves: [BED-9235](https://specterops.atlassian.net/browse/BED-9235)

## Changes

````diff
 // models/app-role-assignments.go — MarshalJSON
 	a.ResourceId = strings.ToUpper(a.ResourceId)
-	a.AppId = strings.ToUpper(a.AppId)
 	a.TenantId = strings.ToUpper(a.TenantId)

 // models/marshal_test.go — regression guard
-	require.Equal(t, "APP-1", out["appId"])
+	require.Equal(t, "app-1", out["appId"])
````

## Impact

| Total AZ edges | AZMGAddOwner | AZMGAddSecret | AZMGAddMember | AZMGGrantRole |
|---|---|---|---|---|
| 545,339 → **2,838,921** | 0 → **1,195,654** | 0 → **977,214** | 0 → **116,923** | 0 → **3,611** |

## Testing

- `go build ./...` and `go test ./...` pass.
- BHE end-to-end (v3.0.0 raw OFF / patched raw OFF / patched raw ON): 0 splits,  0 duplicates, 0 non-uppercase objectids; patched raw OFF == raw ON (byte-identical 2,838,921 edges, so `use_raw_object_id` is a no-op); all `AZMG*` kinds match the v3.0.0 baseline. Residual 115/10-edge diff vs v3.0.0 is collection-time tenant drift, not a code difference.


[BED-9235]: https://specterops.atlassian.net/browse/BED-9235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * App role assignment data now preserves the original casing of the application ID when serialized.
  * Resource and tenant identifiers continue to be normalized as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->