### PR TITLE
BED-9542: fix ghcr creds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,8 +40,8 @@ jobs:
         if: ${{ ! startsWith(github.event_name, 'pull_request') }}
         with:
           registry: ghcr.io
-          username: ${{ secrets.GHCR_USER }}
-          password: ${{ secrets.PACKAGE_SCOPE }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # ratchet:aws-actions/configure-aws-credentials@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -153,8 +153,8 @@ jobs:
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # ratchet:docker/login-action@v4
         with:
           registry: ghcr.io
-          username: ${{ secrets.GHCR_USER }}
-          password: ${{ secrets.PACKAGE_SCOPE }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to ACR
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # ratchet:docker/login-action@v4


### PR DESCRIPTION
The package was using a custom user and token (set in repo secrets) to push to ghcr. now that we're pushing this image to the same org (and not the old org) we can use the default wokflow token.

ref: BED-9542

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container publishing workflows to authenticate with the GitHub Actions actor and token.
  * Existing Azure Container Registry authentication remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->