### PR TITLE
fix: BED-9539 Handle license error when pulling users

### DIFF
--- a/cmd/list-users.go
+++ b/cmd/list-users.go
@@ -152,5 +152,10 @@ func isGraphAuthorizationDenied(err error) bool {
 		return true
 	}
 
+	// The tenant does not have the necessary P2 license that grants access to auditlog.read.all.
+	if strings.Contains(msg, "Authentication_RequestFromNonPremiumTenantOrB2CTenant") && strings.Contains(msgLower, "doesn't have premium license") {
+		return true
+	}
+
 	return false
 }


### PR DESCRIPTION
This PR adds an additional error case to `isGraphAuthorizationDenied()` that was encountered in BED-9539. If that error is encountered when attempting to pull user `signInActivity` then we should now properly retry the request without that property included.

Refs: [BED-9539](https://specterops.atlassian.net/browse/BED-9539)

[BED-9539]: https://specterops.atlassian.net/browse/BED-9539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user listing behavior for certain tenants lacking audit log permissions.
  * Automatically retries without sign-in activity details when access is denied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->